### PR TITLE
Fix phpmd command arg typo

### DIFF
--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -189,7 +189,7 @@ trait CodeAnalysisTasks
             $this->options->analyzedDir,
             $this->options->isSavedToFiles ? 'xml' : 'text',
             escapePath($this->config->path('phpmd.standard')),
-            'sufixxes' => 'php',
+            'suffixes' => 'php',
             $this->options->ignore->phpmd()
         );
         if ($this->options->isSavedToFiles) {


### PR DESCRIPTION
Command line options https://phpmd.org/documentation/index.html