### PR TITLE
phpmetrics will generate an XML report in addition to html

### DIFF
--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -208,6 +208,7 @@ trait CodeAnalysisTasks
         if ($this->options->isSavedToFiles) {
             $args['offline'] = '';
             $args['report-html'] = $this->options->toFile('phpmetrics.html');
+            $args['report-xml'] = $this->options->toFile('phpmetrics.xml');
         } else {
             $args['report-cli'] = '';
         }


### PR DESCRIPTION
CI apps can use the data in this XML file to plot metrics over time. Adding this flag will build the XML report in addition to the HTML report.