### PR TITLE
Added missing property in OptionsTest

### DIFF
--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -18,6 +18,9 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         'execution' => 'parallel',
     );
 
+    /** @var Options */
+    private $fileOutput;
+
     public function setUp()
     {
         $this->fileOutput = $this->overrideOptions();


### PR DESCRIPTION
Hello there,
I tried running my new static analysis tool [PHPStan](https://github.com/phpstan/phpstan) against your codebase and found only one issue - missing property in OptionsTest.

I'd add PHPStan to the dependencies and the build script to check the code continuously in CI, but you are using Symfony 2.8 and PHPStan requires 3.0.

If you are willing to upgrade to Symfony 3.0, I'd happily open another PR that adds PHPStan to the build :)

I'd love if you checked out PHPStan and perhaps gave it a try on your other repos (and even private ones) since it can find a lot of bugs without actually running the code. Cheers!