### PR TITLE
Explicit ext-xsl requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "bin": ["phpqa"],
     "require": {
         "php": ">=5.4",
+        "ext-xsl": "*",
         "henrikbjorn/lurker": "dev-master",
         "codegyre/robo": "*",
         "phpmd/phpmd" : "*",


### PR DESCRIPTION
Instead of (or, in addition to) warning in README about requirements, use it in composer.json