### PR TITLE
Analyze multiple directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ For full documentation please visit [eko3alpha/docker-phpqa](https://hub.docker.
 | Command | Description |
 | ------- | ----------- |
 | `phpqa --help` | Show help - available options, tools, default values, ... |
-| `phpqa --analyzedDir ./ --buildDir ./build` | Analyze current directory and save output to build directory |
+| `phpqa --analyzedDirs ./ --buildDir ./build` | Analyze current directory and save output to build directory |
+| `phpqa --analyzedDirs src,tests` | Analyze source and test directory ([phpmetrics analyzes only `src`](#project-with-multiple-directories-src-tests-)) |
+| ~~`phpqa --analyzedDir ./`~~ | Deprecated in **v1.8** in favor of `--analyzedDirs` |
 | `phpqa --ignoredDirs build,vendor` | Ignore directories |
 | `phpqa --ignoredFiles RoboFile.php` | Ignore files |
 | `phpqa --tools phploc,phpcs` | Run only selected tools |
@@ -226,7 +228,7 @@ Typically in Symfony project you have project with `src` directory with all the 
 ```xml
 <target name="ci-phpqa">
     <exec executable="phpqa" passthru="true">
-        <arg value="--analyzedDir=./src" />
+        <arg value="--analyzedDirs=./src" />
         <arg value="--buildDir=./build/logs" />
         <arg value="--report" />
     </exec>
@@ -239,7 +241,7 @@ Typically in Symfony project you have project with `src` directory with all the 
 public function ciPhpqa()
 {
     $this->taskExec('phpqa')
-        ->option('analyzedDir', './src')
+        ->option('analyzedDirs', './src')
         ->option('buildDir', './build/logs')
         ->option('report')
         ->run();
@@ -251,12 +253,15 @@ public function ciPhpqa()
 When you analyze root directory of your project don't forget to ignore vendors and
 other non-code directories. Otherwise the analysis could take a very long time.
 
+**Since version [1.8](CHANGELOG.md#v180) phpqa supports analyzing multiple directories.**
+Except phpmetrics that analyzes only first directory. Analyze root directory and ignore other directories if you rely on phpmetrics report.
+
 **Phing - `build.xml`**
 
 ```xml
 <target name="ci-phpqa">
     <exec executable="phpqa" passthru="true">
-        <arg value="--analyzedDir=./" />
+        <arg value="--analyzedDirs=./" />
         <arg value="--buildDir=./build/logs" />
         <arg value="--ignoredDirs=app,bin,build,vendor,web" />
         <arg value="--ignoredFiles= " />
@@ -274,7 +279,7 @@ public function ciPhpqa()
     $this->taskExec('phpqa')
         ->option('verbose')
         ->option('report')
-        ->option('analyzedDir', './')
+        ->option('analyzedDirs', './')
         ->option('buildDir', './build')
         ->option('ignoredDirs', 'build,bin,vendor')
         ->option('ignoredFiles', 'RoboFile.php,error-handling.php')
@@ -285,7 +290,7 @@ public function ciPhpqa()
 **Bash**
 
 ```bash
-phpqa --verbose --report --analyzedDir ./ --buildDir ./var/CI --ignoredDirs=bin,log,temp,var,vendor,www
+phpqa --verbose --report --analyzedDirs ./ --buildDir ./var/CI --ignoredDirs=bin,log,temp,var,vendor,www
 ```
 
 ### Circle.ci - artifacts + global installation

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -231,7 +231,7 @@ trait CodeAnalysisTasks
                 $tool->getXmlFiles(),
                 $this->config->path("report.{$tool}"),
                 $tool->htmlReport,
-                ['root-directory' => $this->options->rootPath]
+                ['root-directory' => $this->options->getCommonRootPath()]
             );
         }
         twigToHtml(

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -132,7 +132,7 @@ trait CodeAnalysisTasks
         $args = array(
             'progress' => '',
             $this->options->ignore->bergmann(),
-            $this->options->analyzedDir
+            $this->options->getAnalyzedDirs(' '),
         );
         if ($this->options->isSavedToFiles) {
             $args['log-xml'] = $this->options->toFile('phploc.xml');
@@ -145,7 +145,7 @@ trait CodeAnalysisTasks
         $args = array(
             'progress' => '',
             $this->options->ignore->bergmann(),
-            $this->options->analyzedDir,
+            $this->options->getAnalyzedDirs(' '),
             'min-lines' => $this->config->value('phpcpd.minLines'),
             'min-tokens' => $this->config->value('phpcpd.minTokens'),
         );
@@ -166,7 +166,7 @@ trait CodeAnalysisTasks
             'extensions' => 'php',
             'standard' => $standard,
             $this->options->ignore->phpcs(),
-            $this->options->analyzedDir
+            $this->options->getAnalyzedDirs(' '),
         );
         if ($this->options->isSavedToFiles) {
             $args['report'] = 'checkstyle';
@@ -186,14 +186,14 @@ trait CodeAnalysisTasks
             'jdepend-chart' => $this->options->toFile('pdepend-jdepend.svg'),
             'overview-pyramid' => $this->options->toFile('pdepend-pyramid.svg'),
             $this->options->ignore->pdepend(),
-            $this->options->analyzedDir
+            $this->options->getAnalyzedDirs(','),
         );
     }
 
     private function phpmd(RunningTool $tool)
     {
         $args = array(
-            $this->options->analyzedDir,
+            $this->options->getAnalyzedDirs(','),
             $this->options->isSavedToFiles ? 'xml' : 'text',
             escapePath($this->config->path('phpmd.standard')),
             'suffixes' => 'php',
@@ -207,8 +207,13 @@ trait CodeAnalysisTasks
 
     private function phpmetrics(RunningTool $tool)
     {
+        $analyzedDirs = $this->options->getAnalyzedDirs();
+        $analyzedDir = reset($analyzedDirs);
+        if (count($analyzedDirs) > 1) {
+            $this->say("<error>phpmetrics analyzes only first directory {$analyzedDir}</error>");
+        }
         $args = array(
-            $this->options->analyzedDir,
+            $analyzedDir,
             'extensions' => 'php',
             $this->options->ignore->phpmetrics()
         );

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -54,6 +54,7 @@ trait CodeAnalysisTasks
     /**
      * @description Executes QA tools
      * @option $analyzedDir path to analyzed directory
+     * @option $analyzedDirs csv path(s) to analyzed directories @example src,tests
      * @option $buildDir path to output directory
      * @option $ignoredDirs csv @example CI,bin,vendor
      * @option $ignoredFiles csv @example RoboFile.php
@@ -64,7 +65,8 @@ trait CodeAnalysisTasks
      */
     public function ci(
         $opts = array(
-            'analyzedDir' => './',
+            'analyzedDir' => '',
+            'analyzedDirs' => '',
             'buildDir' => 'build/',
             'ignoredDirs' => 'vendor',
             'ignoredFiles' => '',
@@ -86,6 +88,13 @@ trait CodeAnalysisTasks
 
     private function loadOptions(array $opts)
     {
+        if (!$opts['analyzedDirs']) {
+            $opts['analyzedDirs'] = $opts['analyzedDir'] ?: './';
+            if ($opts['analyzedDir']) {
+                $this->yell("Option --analyzedDir is deprecated, please use option --analyzedDirs");
+            }
+        }
+
         $this->options = new Options($opts);
         $this->usedTools = $this->options->buildRunningTools($this->tools);
         $this->config = new Config();

--- a/src/Options.php
+++ b/src/Options.php
@@ -38,7 +38,7 @@ class Options
             function ($dir) {
                 return '"' . $dir . '"';
             },
-            array_filter(explode(',', $options['analyzedDir']))
+            array_filter(explode(',', $options['analyzedDirs']))
         );
         $this->buildDir = $options['buildDir'];
         $this->isParallel = $options['execution'] == 'parallel';

--- a/src/Options.php
+++ b/src/Options.php
@@ -50,14 +50,14 @@ class Options
 
     public function getCommonRootPath()
     {
-        $paths = array_map(
+        $paths = array_filter(array_map(
             function ($relativeDir) {
-                $path = realpath(getcwd() . '/' . trim($relativeDir, '"'));
-                return $path ? "{$path}/" : '';
+                return realpath(getcwd() . '/' . trim($relativeDir, '"'));
             },
             $this->analyzedDirs
-        );
-        return reset($paths);
+        ));
+        $commonPath = commonPath($paths);
+        return $commonPath ? "{$commonPath}/" : '';
     }
 
     public function getAnalyzedDirs($separator = null)

--- a/src/Options.php
+++ b/src/Options.php
@@ -4,10 +4,8 @@ namespace Edge\QA;
 
 class Options
 {
-    /** @var string */
-    public $analyzedDir;
-    /** @var string */
-    private $rootPath;
+    /** @var string[] */
+    private $analyzedDirs;
     /** @var string */
     public $buildDir;
     /** @var string */
@@ -36,8 +34,12 @@ class Options
 
     private function loadOutput(array $options)
     {
-        $this->analyzedDir = '"' . $options['analyzedDir'] . '"';
-        $this->rootPath = $this->buildRootPath($options['analyzedDir']);
+        $this->analyzedDirs = array_map(
+            function ($dir) {
+                return '"' . $dir . '"';
+            },
+            array_filter(explode(',', $options['analyzedDir']))
+        );
         $this->buildDir = $options['buildDir'];
         $this->isParallel = $options['execution'] == 'parallel';
         $this->isSavedToFiles = $options['output'] == 'file';
@@ -46,15 +48,21 @@ class Options
         $this->configDir = $options['config'] ? $options['config'] : getcwd();
     }
 
-    private function buildRootPath($analyzedDir)
-    {
-        $path = realpath(getcwd() . '/' . $analyzedDir);
-        return $path ? "{$path}/" : '';
-    }
-
     public function getCommonRootPath()
     {
-        return $this->rootPath;
+        $paths = array_map(
+            function ($relativeDir) {
+                $path = realpath(getcwd() . '/' . trim($relativeDir, '"'));
+                return $path ? "{$path}/" : '';
+            },
+            $this->analyzedDirs
+        );
+        return reset($paths);
+    }
+
+    public function getAnalyzedDirs($separator = null)
+    {
+        return $separator ? implode($separator, $this->analyzedDirs) : $this->analyzedDirs;
     }
 
     private function loadTools($inputTools)

--- a/src/Options.php
+++ b/src/Options.php
@@ -7,7 +7,7 @@ class Options
     /** @var string */
     public $analyzedDir;
     /** @var string */
-    public $rootPath;
+    private $rootPath;
     /** @var string */
     public $buildDir;
     /** @var string */
@@ -50,6 +50,11 @@ class Options
     {
         $path = realpath(getcwd() . '/' . $analyzedDir);
         return $path ? "{$path}/" : '';
+    }
+
+    public function getCommonRootPath()
+    {
+        return $this->rootPath;
     }
 
     private function loadTools($inputTools)

--- a/src/paths.php
+++ b/src/paths.php
@@ -11,3 +11,28 @@ function escapePath($path)
 {
     return "\"{$path}\"";
 }
+
+function commonPath(array $dirs)
+{
+    if (!$dirs) {
+        return;
+    }
+
+    $dirsCount = array();
+    foreach ($dirs as $i => $path) {
+        $dirs[$i] = explode('/', $path);
+        unset($dirs[$i][0]);
+        $dirsCount[$i] = count($dirs[$i]);
+    }
+
+    $minDirsCount = min($dirsCount);
+    for ($i = 0; $i < count($dirs); $i++) {
+        $dirs[$i] = '/' . implode('/', array_slice($dirs[$i], 0, $minDirsCount));
+    }
+
+    $commonDirs = array_unique($dirs);
+    while (count($commonDirs) !== 1) {
+        $commonDirs = array_unique(array_map('dirname', $commonDirs));
+    }
+    return reset($commonDirs);
+}

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -7,7 +7,7 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
 {
     // copy-pasted options from CodeAnalysisTasks
     private $defaultOptions = array(
-        'analyzedDir' => './',
+        'analyzedDirs' => './',
         'buildDir' => 'build/',
         'ignoredDirs' => 'vendor',
         'ignoredFiles' => '',
@@ -106,9 +106,9 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @dataProvider provideAnalyzedDir */
-    public function testBuildRootPath($analyzedDir, $expectedRoot)
+    public function testBuildRootPath($analyzedDirs, $expectedRoot)
     {
-        $options = $this->overrideOptions(array('analyzedDir' => $analyzedDir));
+        $options = $this->overrideOptions(array('analyzedDirs' => $analyzedDirs));
         assertThat($options->getCommonRootPath(), is($expectedRoot));
     }
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -116,7 +116,8 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             'current dir + analyzed dir + slash' => array('./', getcwd() . '/'),
-            'no path when dir is invalid' => array('./non-existent-directory', '')
+            'find common root from multiple dirs' => array('src,tests', getcwd() . '/'),
+            'no path when dir is invalid' => array('./non-existent-directory', ''),
         );
     }
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -108,7 +108,7 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     public function testBuildRootPath($analyzedDir, $expectedRoot)
     {
         $options = $this->overrideOptions(array('analyzedDir' => $analyzedDir));
-        assertThat($options->rootPath, is($expectedRoot));
+        assertThat($options->getCommonRootPath(), is($expectedRoot));
     }
 
     public function provideAnalyzedDir()

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -34,7 +34,8 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
 
     public function testShouldEscapePaths()
     {
-        assertThat($this->fileOutput->analyzedDir, is('"./"'));
+        assertThat($this->fileOutput->getAnalyzedDirs(','), is('"./"'));
+        assertThat($this->fileOutput->getAnalyzedDirs(), is(['"./"']));
         assertThat($this->fileOutput->toFile('file'), is('"build//file"'));
         assertThat($this->fileOutput->rawFile('file'), is('build//file'));
     }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -115,7 +115,7 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     public function provideAnalyzedDir()
     {
         return array(
-            'current dir + analyzed dir + slash' => array('./', getcwd() . '/'),
+            'current dir + analyzed dir + slash' => array('src', getcwd() . '/src/'),
             'find common root from multiple dirs' => array('src,tests', getcwd() . '/'),
             'no path when dir is invalid' => array('./non-existent-directory', ''),
         );


### PR DESCRIPTION
- [x] analyze multiple directories
- [x] add warning that phpmetrics analyzes only first directory
- [x] hide [common root path](https://www.rosettacode.org/wiki/Find_common_directory_path#PHP) in html reports
- [x] add new options `--analyzedDirs`, deprecate `--analyzedDir

Closes https://github.com/EdgedesignCZ/phpqa/issues/38`