### PR TITLE
Show parsing errors in phpmd report

### DIFF
--- a/app/report/phpmd.xsl
+++ b/app/report/phpmd.xsl
@@ -51,6 +51,9 @@
                         <li role="presentation">
                             <a href="#errors" aria-controls="errors" role="tab" data-toggle="tab">Errors</a>
                         </li>
+                        <li role="presentation">
+                            <a href="#parsing" aria-controls="parsing" role="tab" data-toggle="tab">Parsing Errors</a>
+                        </li>
                     </ul>
                 </nav>
 
@@ -183,6 +186,23 @@
                                         <td><xsl:value-of select="@beginline" />-<xsl:value-of select="@endline" /></td>
                                     </tr>
                                 </xsl:for-each>
+                            </xsl:for-each>
+                        </table>
+                    </div>
+
+                    <div role="tabpanel" class="tab-pane" id="parsing">
+                        <table class="table table-striped">
+                            <thead>
+                                <tr>
+                                    <th>File</th>
+                                    <th>Error</th>
+                                </tr>
+                            </thead>
+                            <xsl:for-each select="/pmd/error">
+                                <tr>
+                                    <td><strong data-file=""><xsl:value-of select="@filename" /></strong></td>
+                                    <td><xsl:value-of select="@msg" /></td>
+                                </tr>
                             </xsl:for-each>
                         </table>
                     </div>

--- a/app/report/phpqa.html.twig
+++ b/app/report/phpqa.html.twig
@@ -27,6 +27,7 @@ set tabs = {
     'phpmd': {
         'overview': 'Overview',
         'errors': 'Errors',
+        'parsing': 'Parsing Errors',
     }, 
     'phpcpd': {
         'overview': 'Overview',


### PR DESCRIPTION
phpmd knows about invalid php syntax, but it's not displayed in html report

```
<error filename="src/invalid.php" msg="Unexpected token: ;, line: 3, col: 7, file: src/invalid.php." />
```

![screenshot from 2016-12-21 16 31 39](https://cloud.githubusercontent.com/assets/7994022/21394949/f7b28706-c79a-11e6-8fe9-ddc5906fa544.png)

