### PR TITLE
phpqa tools - load package information from composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then composer update && composer require sebastian/phpcpd:dev-master && bin/suggested-tools.sh install; fi
 script:
   - vendor/phpunit/phpunit/phpunit
+  - ./phpqa tools
   - bin/ci.sh
 # http://blog.wyrihaximus.net/2015/07/composer-cache-on-travis/
 cache:

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -8,34 +8,41 @@ trait CodeAnalysisTasks
     private $tools = array(
         'phpmetrics' => array(
             'optionSeparator' => ' ',
+            'composer' => 'phpmetrics/phpmetrics',
         ),
         'phploc' => array(
             'optionSeparator' => ' ',
             'xml' => ['phploc.xml'],
+            'composer' => 'phploc/phploc',
         ),
         'phpcs' => array(
             'optionSeparator' => '=',
             'xml' => ['checkstyle.xml'],
             'errorsXPath' => '//checkstyle/file/error',
+            'composer' => 'squizlabs/php_codesniffer',
         ),
         'phpmd' => array(
             'optionSeparator' => ' ',
             'xml' => ['phpmd.xml'],
             'errorsXPath' => '//pmd/file/violation',
+            'composer' => 'phpmd/phpmd',
         ),
         'pdepend' => array(
             'optionSeparator' => '=',
             'xml' => ['pdepend-jdepend.xml', 'pdepend-summary.xml', 'pdepend-dependencies.xml'],
+            'composer' => 'pdepend/pdepend',
         ),
         'phpcpd' => array(
             'optionSeparator' => ' ',
             'xml' => ['phpcpd.xml'],
             'errorsXPath' => '//pmd-cpd/duplication',
+            'composer' => 'sebastian/phpcpd',
         ),
         'parallel-lint' => array(
             'optionSeparator' => ' ',
             'internalClass' => 'JakubOnderka\PhpParallelLint\ParallelLint',
             'hasOnlyConsoleOutput' => true,
+            'composer' => 'jakub-onderka/php-parallel-lint',
         ),
     );
     /** @var Options */
@@ -51,7 +58,7 @@ trait CodeAnalysisTasks
     public function tools()
     {
         $tools = new Task\ToolVersions($this->getOutput());
-        $tools(array_keys($this->tools));
+        $tools($this->tools);
     }
 
     /**

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -50,17 +50,8 @@ trait CodeAnalysisTasks
      */
     public function tools()
     {
-        $this->yell("phpqa v" . PHPQA_VERSION);
-        foreach (array_keys($this->tools) as $tool) {
-            if ($tool == 'parallel-lint') {
-                $task = $this->taskExec(pathToBinary("{$tool}"))
-                    ->printed(false)
-                    ->run();
-                $this->getOutput()->writeln(strtok($task->getMessage(), "\n"));
-            } else {
-                $this->_exec(pathToBinary("{$tool} --version"));
-            }
-        }
+        $tools = new Task\ToolVersions($this->getOutput());
+        $tools(array_keys($this->tools));
     }
 
     /**

--- a/src/Task/ToolVersions.php
+++ b/src/Task/ToolVersions.php
@@ -66,6 +66,7 @@ class ToolVersions
         $composerInfo = array_key_exists($composerPackage, $composerPackages) ?
             get_object_vars($composerPackages[$composerPackage]) :
             [
+                'version' => '',
                 'version_normalized' => '<error>not installed</error>',
                 'authors' => [(object) ['name' => "<info>composer require {$composerPackage}</info>"]],
             ];
@@ -76,14 +77,17 @@ class ToolVersions
 
         return array(
             "<comment>{$tool}</comment>",
-            $this->stripTrailingZeroVersion($composerInfo['version_normalized']),
+            $this->normalizeVersion($composerInfo),
             $this->groupAuthors($composerInfo['authors'])
         );
     }
 
-    private function stripTrailingZeroVersion($version)
+    private function normalizeVersion(array $composerInfo)
     {
-        return preg_replace('/\.0$/s', '', $version);
+        if ($composerInfo['version_normalized'] == '9999999-dev') {
+            return $composerInfo['version'];
+        }
+        return preg_replace('/\.0$/s', '', $composerInfo['version_normalized']);
     }
 
     private function groupAuthors(array $composerAuthors)

--- a/src/Task/ToolVersions.php
+++ b/src/Task/ToolVersions.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Edge\QA\Task;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Robo\Task\Base\Exec;
+
+class ToolVersions
+{
+    private $output;
+    
+    public function __construct(OutputInterface $p)
+    {
+        $this->output = $p;
+    }
+
+    public function __invoke(array $tools)
+    {
+        $this->output->writeln([
+            '<comment>phpqa ' . PHPQA_VERSION . '</comment>',
+            '',
+        ]);
+
+        foreach ($tools as $tool) {
+            $versionCommand = $tool == 'parallel-lint' ? $tool : "{$tool} --version";
+            $this->loadVersionFromConsoleCommand($versionCommand);
+        }
+    }
+
+    private function loadVersionFromConsoleCommand($command)
+    {
+        $exec = new Exec(\Edge\QA\pathToBinary($command));
+        $result = $exec
+            ->printed(false)
+            ->run()
+            ->getMessage();
+        $this->output->writeln($this->getFirstLine($result));
+    }
+
+    private function getFirstLine($string)
+    {
+        return strtok($string, "\n");
+    }
+}

--- a/src/Task/ToolVersions.php
+++ b/src/Task/ToolVersions.php
@@ -2,19 +2,104 @@
 
 namespace Edge\QA\Task;
 
-use Symfony\Component\Console\Output\OutputInterface;
 use Robo\Task\Base\Exec;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
 
 class ToolVersions
 {
     private $output;
-    
+
     public function __construct(OutputInterface $p)
     {
         $this->output = $p;
     }
 
-    public function __invoke(array $tools)
+    public function __invoke(array $qaTools)
+    {
+        $composerPackages = $this->findComposerPackages();
+        if ($composerPackages) {
+            $this->composerInfo($qaTools, $composerPackages);
+        } else {
+            $this->consoleInfo(array_keys($qaTools));
+        }
+    }
+
+    private function findComposerPackages()
+    {
+        $installedJson = COMPOSER_BINARY_DIR . '/../composer/installed.json';
+        if (!is_file($installedJson)) {
+            return [];
+        }
+
+        $installedTools = json_decode(file_get_contents($installedJson));
+        if (!is_array($installedTools)) {
+            return [];
+        }
+
+        $tools = array();
+        foreach ($installedTools as $tool) {
+            $tools[$tool->name] = $tool;
+        }
+
+        return $tools + [
+            'edgedesign/phpqa' => (object) [
+                'version_normalized' => PHPQA_VERSION,
+                'authors' => [(object) ['name' => "Zdeněk Drahoš"]],
+            ]
+        ];
+    }
+
+    private function composerInfo(array $qaTools, array $composerPackages)
+    {
+        $table = new Table($this->output);
+        $table->setHeaders(['Tool', 'Version', 'Authors']);
+        $table->addRow($this->toolToTableRow('phpqa', 'edgedesign/phpqa', $composerPackages));
+        foreach ($qaTools as $tool => $config) {
+            $table->addRow($this->toolToTableRow($tool, $config['composer'], $composerPackages));
+        }
+        $table->render();
+    }
+
+    private function toolToTableRow($tool, $composerPackage, array $composerPackages)
+    {
+        $composerInfo = array_key_exists($composerPackage, $composerPackages) ?
+            get_object_vars($composerPackages[$composerPackage]) :
+            [
+                'version_normalized' => '<error>not installed</error>',
+                'authors' => [(object) ['name' => "<info>composer require {$composerPackage}</info>"]],
+            ];
+        $composerInfo += [
+            'version_normalized' => '',
+            'authors' => [(object) ['name' => '']],
+        ];
+
+        return array(
+            "<comment>{$tool}</comment>",
+            $this->stripTrailingZeroVersion($composerInfo['version_normalized']),
+            $this->groupAuthors($composerInfo['authors'])
+        );
+    }
+
+    private function stripTrailingZeroVersion($version)
+    {
+        return preg_replace('/\.0$/s', '', $version);
+    }
+
+    private function groupAuthors(array $composerAuthors)
+    {
+        return implode(
+            ',',
+            array_map(
+                function ($author) {
+                    return $author->name;
+                },
+                $composerAuthors
+            )
+        );
+    }
+
+    private function consoleInfo(array $tools)
     {
         $this->output->writeln([
             '<comment>phpqa ' . PHPQA_VERSION . '</comment>',


### PR DESCRIPTION
[Recommended](https://github.com/EdgedesignCZ/phpqa/pull/43#issuecomment-268851201) ocramius package looks complex and could cause [unexpected errors](https://github.com/Ocramius/PackageVersions/issues/38). It also requires `php7`. Parsing `installed.json` with fallback is good enough.

![screenshot from 2016-12-23 11 00 06](https://cloud.githubusercontent.com/assets/7994022/21451392/296f40b2-c8ff-11e6-8871-bd98a21b9e5a.png)
