### PR TITLE
Test against the current hhvm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 7.0
   - 7.1
 matrix:
-  fast_finish: true
   include:
     - php: hhvm
       sudo: true
@@ -18,9 +17,6 @@ install:
   - composer install --no-interaction
   # test app with symfony3 components in latest php
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then composer update && composer require sebastian/phpcpd:dev-master && bin/suggested-tools.sh install; fi
-before_script:
-  # Disable the HHVM JIT for faster Unit Testing
-  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
 script:
   - vendor/phpunit/phpunit/phpunit
   - ./phpqa tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,21 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+matrix:
+  fast_finish: true
+  include:
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # Until the next Travis stable image update
 install:
   - if [ -n "$GITHUB_OAUTH_TOKEN" ]; then composer config github-oauth.github.com ${GITHUB_OAUTH_TOKEN}; fi;
   - composer install --no-interaction
   # test app with symfony3 components in latest php
   - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then composer update && composer require sebastian/phpcpd:dev-master && bin/suggested-tools.sh install; fi
+before_script:
+  # Disable the HHVM JIT for faster Unit Testing
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
 script:
   - vendor/phpunit/phpunit/phpunit
   - ./phpqa tools


### PR DESCRIPTION
You are currently testing against a long EOL version of HHVM (3.6.6)

This provides the current HHVM version (3.17.0 as of this PR) and will track with each release (i.e. will be 3.18 when 3.18 is released.

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

Should be able to change to container based Trusty after Q1-17 https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/