### PR TITLE
Custom binary location

### DIFF
--- a/phpqa
+++ b/phpqa
@@ -11,6 +11,10 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/../../autoload.php';
 }
 
+if (!defined('COMPOSER_BINARY_DIR') || !is_file(COMPOSER_BINARY_DIR . 'phploc')) {
+    die("Composer binary directory was not found\n");
+}
+
 /**
  * RoboFile is in phpqa repository, but analysis is runned in cwd.
  * Robo\Runner:loadRoboFile calls chdir when option --load-from=__DIR__

--- a/phpqa
+++ b/phpqa
@@ -7,12 +7,24 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     define('COMPOSER_BINARY_DIR', __DIR__ . "/vendor/bin/");
     require_once __DIR__ . '/vendor/autoload.php';
 } elseif (file_exists(__DIR__ . '/../../autoload.php')) {
-    define('COMPOSER_BINARY_DIR', __DIR__ . "/../../bin/");
+    $projectRoot = __DIR__ . '/../../..';
+    $binPaths = [
+        "{$projectRoot}/vendor/bin",
+        "{$projectRoot}/bin",
+        $projectRoot,
+        "{$projectRoot}/" . getenv('COMPOSER_BIN_DIR'),
+    ];
+    foreach ($binPaths as $bin) {
+        if (is_file("{$bin}/phploc")) {
+            define('COMPOSER_BINARY_DIR', "{$bin}/");
+            break;
+        }
+    }
     require_once __DIR__ . '/../../autoload.php';
 }
 
 if (!defined('COMPOSER_BINARY_DIR') || !is_file(COMPOSER_BINARY_DIR . 'phploc')) {
-    die("Composer binary directory was not found\n");
+    die("Composer binary directory was not found (define path in environment variable 'COMPOSER_BIN_DIR')\n");
 }
 
 /**


### PR DESCRIPTION
- [x] detect [composer bin dir](https://getcomposer.org/doc/articles/vendor-binaries.md#can-vendor-binaries-be-installed-somewhere-other-than-vendor-bin-) in common paths or use env variable `COMPOSER_BIN_DIR`
- [x] stop phpqa if `bin-dir` is in unknown location

Closes #46 