### PR TITLE
ciClean is always trying to _mkdir

### DIFF
--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -172,8 +172,9 @@ trait CodeAnalysisTasks
         if ($this->options->isSavedToFiles) {
             if (is_dir($this->options->buildDir)) {
                 $this->_cleanDir($this->options->buildDir);
+            } else {
+                $this->_mkdir($this->options->buildDir);
             }
-            $this->_mkdir($this->options->buildDir);
         }
     }
 


### PR DESCRIPTION
This is creating a nativecommanderror every time this is run which is noisy and unnecessary

[ERROR] + .\lib\vendor\bin\phpqa --config .\lib\tests --buildDir .\ ...
[ERROR] + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ERROR]     + CategoryInfo          : NotSpecified: ( [Filesystem\Cl...Lib\tests\build 
[ERROR]    :String) [], RemoteException
[ERROR]     + FullyQualifiedErrorId : NativeCommandError
[ERROR]  
[ERROR]  [Filesystem\FilesystemStack] mkdir [".\\lib\\tests\\build"]

Simple fix only calls the mkdir command if the directory doesn't actually exist