### PR TITLE
Support phploc v4.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - if [ -n "$GITHUB_OAUTH_TOKEN" ]; then composer config github-oauth.github.com ${GITHUB_OAUTH_TOKEN}; fi;
   - composer install --no-interaction
   # test app with symfony3 components in latest php
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then composer update && composer remove phpunit/phpunit --dev --no-interaction && composer require sebastian/phpcpd:~3.0 phpunit/phpunit:~5.7 && bin/suggested-tools.sh install; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then composer update && composer remove phpunit/phpunit --dev --no-interaction && composer require sebastian/phpcpd:~3.0 phploc/phploc:~4 phpunit/phpunit:~5.7 && bin/suggested-tools.sh install; fi
   # For HHVM phpmetrics report isn't generated, use phpmetrics v2
   - if [[ $TRAVIS_PHP_VERSION = hhvm* ]] ; then composer update phpmetrics/phpmetrics; fi
 script:

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -206,7 +206,6 @@ trait CodeAnalysisTasks
     private function phploc()
     {
         $args = array(
-            'progress' => '',
             $this->options->ignore->bergmann(),
             $this->options->getAnalyzedDirs(' '),
         );


### PR DESCRIPTION
[ProgressBar](https://github.com/sebastianbergmann/phploc/blob/2.0/src/CLI/Command.php#L201) is used for git revisions, unused in phpqa. So there is no need to keep `--progress` option.

Closes https://github.com/EdgedesignCZ/phpqa/issues/72