### PR TITLE
Support phpmetrics v1 configuration

### DIFF
--- a/.phpqa.yml
+++ b/.phpqa.yml
@@ -28,6 +28,9 @@ phpcpd:
     minLines: 5
     minTokens: 70
 
+phpmetrics:
+    config: null
+
 phpstan:
     level: 0
     # https://github.com/phpstan/phpstan#configuration

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./phpqa --verbose --report --config tests/.travis --tools phpcs:0,php-cs-fixer:0,phpmd:0,phpcpd:0,parallel-lint:0,phpstan,phpmetrics,phploc,pdepend
+./phpqa --verbose --report --config tests/.travis --tools phpcs:0,php-cs-fixer:0,phpmd:0,phpcpd:0,parallel-lint:0,phpstan,phpmetrics:0,phploc,pdepend

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -317,6 +317,10 @@ trait CodeAnalysisTasks
             $args['offline'] = '';
             $args['report-html'] = escapePath($tool->htmlReport);
             $args['report-xml'] = $this->options->toFile('phpmetrics.xml');
+            $configFile = $this->config->value('phpmetrics.config');
+            if ($configFile) {
+                $args['config'] = $configFile;
+            }
         } else {
             $args['report-cli'] = '';
         }

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -9,6 +9,7 @@ trait CodeAnalysisTasks
         'phpmetrics' => array(
             'optionSeparator' => ' ',
             'composer' => 'phpmetrics/phpmetrics',
+            'outputMode' => OutputMode::CUSTOM_OUTPUT_AND_EXIT_CODE,
         ),
         'phpmetrics2' => array(
             'optionSeparator' => '=',

--- a/src/OutputMode.php
+++ b/src/OutputMode.php
@@ -7,4 +7,5 @@ class OutputMode
     const HANDLED_BY_TOOL = 0;
     const RAW_CONSOLE_OUTPUT = 1;
     const XML_CONSOLE_OUTPUT = 2;
+    const CUSTOM_OUTPUT_AND_EXIT_CODE = 3;
 }

--- a/src/RunningTool.php
+++ b/src/RunningTool.php
@@ -70,7 +70,10 @@ class RunningTool
     {
         $xpath = $this->errorsXPath[$this->errorsType];
 
-        if ($hasNoOutput || $this->hasOutput(OutputMode::RAW_CONSOLE_OUTPUT)) {
+        if ($hasNoOutput ||
+            $this->hasOutput(OutputMode::RAW_CONSOLE_OUTPUT) ||
+            $this->hasOutput(OutputMode::CUSTOM_OUTPUT_AND_EXIT_CODE)
+        ) {
             return $this->evaluteErrorsCount($this->process->getExitCode() ? 1 : 0);
         } elseif (!$xpath) {
             return [true, ''];

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -17,6 +17,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         assertThat($config->value('php-cs-fixer.isDryRun'), identicalTo(true));
         assertThat($config->value('php-cs-fixer.allowRiskyRules'), identicalTo(false));
         assertThat($config->path('php-cs-fixer.config'), is(nullValue()));
+        assertThat($config->path('phpmetrics.config'), is(nullValue()));
         assertThat($config->path('phpmd.standard'), is(nonEmptyString()));
         assertThat($config->value('phpstan.level'), identicalTo(0));
     }


### PR DESCRIPTION
Closes https://github.com/EdgedesignCZ/phpqa/issues/74

- [x] load [config](https://github.com/phpmetrics/PhpMetrics/blob/legacy-v1/.phpmetrics.yml.dist) from `.phpqa.yml`
- [x] evalute exit code ([1](https://github.com/EdgedesignCZ/phpqa/issues/74) when `failureCondition` is met)

