### PR TITLE
Fix binary path, process timeout, ignoring directories on Windows

### DIFF
--- a/src/IgnoredPaths.php
+++ b/src/IgnoredPaths.php
@@ -7,12 +7,19 @@ class IgnoredPaths
     private $ignoreDirs;
     private $ignoreFiles;
     private $ignoreBoth;
+    private $isWindows;
 
     public function __construct($ignoredDirs, $ignoredFiles)
     {
         $this->ignoreDirs = $this->csvToArray($ignoredDirs);
         $this->ignoreFiles = $this->csvToArray($ignoredFiles);
         $this->ignoreBoth = array_merge($this->ignoreDirs, $this->ignoreFiles);
+        $this->setOS(PHP_OS);
+    }
+
+    public function setOS($os)
+    {
+        $this->isWindows = strtoupper(substr($os, 0, 3)) == 'WIN';
     }
 
     private function csvToArray($csv)
@@ -27,12 +34,23 @@ class IgnoredPaths
 
     public function pdepend()
     {
+        if ($this->isWindows) {
+            return $this->pdependWindowsFilter('ignore');
+        }
         return $this->ignore(' --ignore=/', '/,/', '/', ',/');
     }
 
     public function phpmd()
     {
+        if ($this->isWindows) {
+            return $this->pdependWindowsFilter('exclude');
+        }
         return $this->ignore(" --exclude /", '/,/', '/', ',/');
+    }
+
+    private function pdependWindowsFilter($option)
+    {
+        return $this->ignore(" --{$option}=", '\*,', '\*', ',');
     }
 
     public function phpmetrics()

--- a/src/Task/NonParallelExecV1.php
+++ b/src/Task/NonParallelExecV1.php
@@ -21,6 +21,8 @@ class NonParallelExecV1 extends ParallelExec
     public function run()
     {
         foreach ($this->processes as $process) {
+            $process->setIdleTimeout($this->idleTimeout);
+            $process->setTimeout($this->timeout);
             $this->printTaskInfo($process->getCommandLine());
         }
 

--- a/src/paths.php
+++ b/src/paths.php
@@ -4,7 +4,7 @@ namespace Edge\QA;
 
 function pathToBinary($tool)
 {
-    return COMPOSER_BINARY_DIR . $tool;
+    return escapePath(COMPOSER_BINARY_DIR . $tool);
 }
 
 function escapePath($path)

--- a/tests/IgnoredPathsTest.php
+++ b/tests/IgnoredPathsTest.php
@@ -4,9 +4,12 @@ namespace Edge\QA;
 
 class IgnoredPathsTest extends \PHPUnit_Framework_TestCase
 {
+    private $operatingSystem = 'Linux';
+
     private function ignore($tool, $dirs, $files)
     {
         $paths = new IgnoredPaths($dirs, $files);
+        $paths->setOS($this->operatingSystem);
         return $paths->$tool();
     }
 
@@ -17,11 +20,17 @@ class IgnoredPathsTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @dataProvider provideTools */
-    public function testShouldIgnoreDirectories($tool, $expectedOptions)
+    public function testIgnoreDirectoriesAndFiles($tool, $expectedOptions, $os = null)
     {
-        assertThat($this->ignore($tool, 'bin,vendor', 'autoload.php,RoboFile.php'), is($expectedOptions['both']));
-        assertThat($this->ignore($tool, 'bin,vendor', ''), is($expectedOptions['dirs']));
-        assertThat($this->ignore($tool, '', 'autoload.php,RoboFile.php'), is($expectedOptions['files']));
+        $this->operatingSystem = $os ?: $this->operatingSystem;
+        $this->assertEquals(
+            $expectedOptions,
+            [
+                'both' => $this->ignore($tool, 'bin,vendor', 'autoload.php,RoboFile.php'),
+                'dirs' => $this->ignore($tool, 'bin,vendor', ''),
+                'files' => $this->ignore($tool, '', 'autoload.php,RoboFile.php'),
+            ]
+        );
     }
 
     public function provideTools()
@@ -50,6 +59,24 @@ class IgnoredPathsTest extends \PHPUnit_Framework_TestCase
                     'dirs' => ' --exclude /bin/,/vendor/',
                     'files' => ' --exclude /autoload.php,/RoboFile.php'
                 )
+            ),
+            'pdepend + windows' => array(
+                'pdepend',
+                array(
+                    'both' => ' --ignore=bin\*,vendor\*,autoload.php,RoboFile.php',
+                    'dirs' => ' --ignore=bin\*,vendor\*',
+                    'files' => ' --ignore=autoload.php,RoboFile.php'
+                ),
+                'Windows'
+            ),
+            'phpmd + windows' => array(
+                'phpmd',
+                array(
+                    'both' => ' --exclude=bin\*,vendor\*,autoload.php,RoboFile.php',
+                    'dirs' => ' --exclude=bin\*,vendor\*',
+                    'files' => ' --exclude=autoload.php,RoboFile.php'
+                ),
+                'WIN32'
             ),
             array(
                 'phpmetrics',

--- a/tests/PathsTest.php
+++ b/tests/PathsTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Edge\QA;
+
+class PathsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPathToBinaryIsEscaped()
+    {
+        define('COMPOSER_BINARY_DIR', '/home/user with space/phpqa/vendor/bin');
+        assertThat(pathToBinary('phpcs'), allOf(startsWith('"'), endsWith('"')));
+    }
+}


### PR DESCRIPTION
- [x] https://github.com/EdgedesignCZ/phpqa/issues/76 Fix escaping binary path
- [x] https://github.com/EdgedesignCZ/phpqa/issues/77 Don't use default 60s timeout is non-parallel execution 
- [x] https://github.com/EdgedesignCZ/phpqa/issues/75 Fix ignoring phpmd/pdepend directories on Windows