### PR TITLE
Support phpunit

### DIFF
--- a/.phpqa.yml
+++ b/.phpqa.yml
@@ -36,6 +36,15 @@ phpstan:
     # https://github.com/phpstan/phpstan#configuration
     # standard: tests/.travis/phpstan.neon
 
+phpunit:
+    # phpunit.xml
+    config: null
+    reports:
+        file: []
+            # log: [junit, tap, json]
+            # testdox: [html, text]
+            # coverage: [html, clover, crap4j, php, text, xml] # requires XDebug extension
+
 # paths are relative to .phpqa.yml, so don't copy-paste this section if you don't have custom templates
 report:
     phploc: app/report/phploc.xsl

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Tool | PHP | Supported since | Description | Status |
 [php-cs-fixer](http://cs.sensiolabs.org/) | [`>= 5.3`](https://github.com/EdgedesignCZ/phpqa/pull/66#discussion_r115206573) | `1.12` | Automatically detect and fix PHP coding standards issues | stable |
 [parallel-lint](https://github.com/JakubOnderka/PHP-Parallel-Lint) | `>= 5.4` | `1.9` | Check syntax of PHP files | stable |
 [phpstan](https://github.com/phpstan/phpstan) | `>= 7.0` | `1.9` | Discover bugs in your code without running it | _experimental_ ([`v0.7`](https://github.com/EdgedesignCZ/phpqa/pull/43)) |
+[phpunit](https://github.com/phpunit/phpunit) | `>= 5.3` | `1.13` | The PHP Unit Testing framework | _experimental_ |
 
 _Tip_: use [`bin/suggested-tools.sh install`](/bin/suggested-tools.sh) for installing the tools.
 
@@ -208,6 +209,8 @@ Tool | Settings | Default Value | Your value
 [phpmd](http://phpmd.org/documentation/creating-a-ruleset.html) | Ruleset | [Edgedesign's standard](/app/phpmd.xml) | Path to ruleset
 [phpcpd](https://github.com/sebastianbergmann/phpcpd/blob/de9056615da6c1230f3294384055fa7d722c38fa/src/CLI/Command.php#L136) | Minimum number of lines/tokens for copy-paste detection | 5 lines, 70 tokens | 
 [phpstan](https://github.com/phpstan/phpstan#configuration) | Level, config file | Level 0, `%currentWorkingDirectory%/phpstan.neon` | Take a look at [phpqa config in tests/.travis](/tests/.travis/) |
+[phpunit.config](https://phpunit.de/manual/current/en/organizing-tests.html#organizing-tests.xml-configuration) | PHPUnit configuration, `analyzedDirs` and `ignoredDirs` are not used, you have to specify test suites in XML file | `null` | Path to `phpunit.xml` file
+[phpunit.reports](https://phpunit.de/manual/current/en/textui.html) | Report types  | no report | List of reports and formats, corresponds with CLI option, e.g. `--log-junit` is `log: [junit]` in `.phpqa.yml` |
 
 `.phpqa.yml` is automatically detected in current working directory, but you can specify
 directory via option:

--- a/app/report/phpqa.html.twig
+++ b/app/report/phpqa.html.twig
@@ -42,6 +42,9 @@ set tabs = {
         'ccn': 'Cyclomatic Complexity',
         'dependencies': 'Dependencies',
     },
+    'phpunit': {
+        'overview': 'Overview',
+    },
 }
 %}
 <html>

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./phpqa --verbose --report --config tests/.travis --tools phpcs:0,php-cs-fixer:0,phpmd:0,phpcpd:0,parallel-lint:0,phpstan,phpmetrics:0,phploc,pdepend
+./phpqa --verbose --report --config tests/.travis --tools phpcs:0,php-cs-fixer:0,phpmd:0,phpcpd:0,parallel-lint:0,phpstan,phpmetrics:0,phploc,pdepend,phpunit:0

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "friendsofphp/php-cs-fixer": "A tool to automatically fix PHP coding standards issues",
         "jakub-onderka/php-parallel-lint": "Check PHP syntax",
         "jakub-onderka/php-console-highlighter": "Colored output in parallel-lint",
-        "phpstan/phpstan": "PHP Static Analysis Tool - discover bugs in your code without running it!"
+        "phpstan/phpstan": "PHP Static Analysis Tool - discover bugs in your code without running it!",
+        "phpunit/phpunit": "The PHP Unit Testing framework"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -81,7 +81,7 @@ trait CodeAnalysisTasks
         ),
         'phpunit' => array(
             'optionSeparator' => '=',
-            'internalClass' => 'PHPUnit_Framework_TestCase',
+            'internalClass' => ['PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase'],
             'outputMode' => OutputMode::RAW_CONSOLE_OUTPUT,
             'composer' => 'phpunit/phpunit',
         ),

--- a/src/RunningTool.php
+++ b/src/RunningTool.php
@@ -6,7 +6,7 @@ class RunningTool
 {
     private $tool;
     public $binary;
-    private $internalClass;
+    private $internalClasses;
     private $optionSeparator;
     private $outputMode;
 
@@ -33,7 +33,7 @@ class RunningTool
         ];
         $this->tool = $tool;
         $this->binary = $config['binary'];
-        $this->internalClass = $config['internalClass'];
+        $this->internalClasses = $config['internalClass'] ? ((array) $config['internalClass']) : array();
         $this->optionSeparator = $config['optionSeparator'];
         $this->xmlFiles = $config['xml'];
         $this->errorsXPath = is_array($config['errorsXPath'])
@@ -44,7 +44,15 @@ class RunningTool
 
     public function isInstalled()
     {
-        return !$this->internalClass || class_exists($this->internalClass);
+        if (!$this->internalClasses) {
+            return true;
+        }
+        foreach ($this->internalClasses as $class) {
+            if (class_exists($class)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public function hasOutput($outputMode)

--- a/tests/.travis/.phpqa.yml
+++ b/tests/.travis/.phpqa.yml
@@ -12,3 +12,10 @@ phpstan:
     level: 7
     # https://github.com/phpstan/phpstan#configuration
     standard: phpstan.neon
+
+phpunit:
+    config: phpunit.xml
+    reports:
+        file:
+            log: [junit]
+            testdox: [html, text]

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -20,6 +20,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         assertThat($config->path('phpmetrics.config'), is(nullValue()));
         assertThat($config->path('phpmd.standard'), is(nonEmptyString()));
         assertThat($config->value('phpstan.level'), identicalTo(0));
+        assertThat($config->value('phpunit.config'), is(nullValue()));
+        assertThat($config->value('phpunit.reports.file'), is(emptyArray()));
     }
 
     public function testBuildAbsolutePath()


### PR DESCRIPTION
https://github.com/EdgedesignCZ/phpqa/issues/80, example report at https://edgedesigncz.github.io/phpqa/report/phpqa.html

Experimental support for phpunit. Reports are configurable in `.phpqa.yml`, everything else should be `phpunit.xml`.

_Why experimental?_ Could cause troubles when phpunit version in phpqa is different than in analyzed code.