### PR TITLE
Allow using custom binary

### DIFF
--- a/.phpqa.yml
+++ b/.phpqa.yml
@@ -37,6 +37,8 @@ phpstan:
     # standard: tests/.travis/phpstan.neon
 
 phpunit:
+    # binary: vendor/bin/phpunit
+    binary: null
     # phpunit.xml
     config: null
     reports:

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Tool | Settings | Default Value | Your value
 [phpmd](http://phpmd.org/documentation/creating-a-ruleset.html) | Ruleset | [Edgedesign's standard](/app/phpmd.xml) | Path to ruleset
 [phpcpd](https://github.com/sebastianbergmann/phpcpd/blob/de9056615da6c1230f3294384055fa7d722c38fa/src/CLI/Command.php#L136) | Minimum number of lines/tokens for copy-paste detection | 5 lines, 70 tokens |
 [phpstan](https://github.com/phpstan/phpstan#configuration) | Level, config file | Level 0, `%currentWorkingDirectory%/phpstan.neon` | Take a look at [phpqa config in tests/.travis](/tests/.travis/) |
+[phpunit.binary](https://github.com/EdgedesignCZ/phpqa/blob/4947416/.phpqa.yml#L40) | Phpunit binary  | phpqa's phpunit | Path to phpunit executable in your project, typically [`vendor/bin/phpunit`](https://gitlab.com/costlocker/integrations/blob/master/basecamp/backend/.phpqa.yml#L2) |
 [phpunit.config](https://phpunit.de/manual/current/en/organizing-tests.html#organizing-tests.xml-configuration) | PHPUnit configuration, `analyzedDirs` and `ignoredDirs` are not used, you have to specify test suites in XML file | `null` | Path to `phpunit.xml` file
 [phpunit.reports](https://phpunit.de/manual/current/en/textui.html) | Report types  | no report | List of reports and formats, corresponds with CLI option, e.g. `--log-junit` is `log: [junit]` in `.phpqa.yml` |
 [psalm.config](https://github.com/vimeo/psalm/wiki/Configuration) | Psalm configuration, `analyzedDirs` and `ignoredDirs` are not used, you have to specify projectFiles in XML file | `null` | Path to `psalm.xml` file

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -110,6 +110,8 @@ trait CodeAnalysisTasks
     private $config;
     /** @var RunningTool[] */
     private $usedTools;
+    /** @var string[] */
+    private $skippedTools;
 
     /**
      * @description Current versions
@@ -168,7 +170,7 @@ trait CodeAnalysisTasks
         $this->options = new Options($opts);
         $this->config = new Config();
         $this->config->loadCustomConfig($this->options->configDir, $opts['config']);
-        $this->usedTools = $this->options->buildRunningTools(
+        list($this->usedTools, $this->skippedTools) = $this->options->buildRunningTools(
             $this->tools,
             function ($tool) {
                 return $this->config->value("{$tool}.binary");
@@ -554,6 +556,6 @@ trait CodeAnalysisTasks
     private function buildSummary()
     {
         $summary = new Task\TableSummary($this->options, $this->getOutput());
-        return $summary($this->usedTools);
+        return $summary($this->usedTools, $this->skippedTools);
     }
 }

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -118,7 +118,7 @@ trait CodeAnalysisTasks
      * @option $config path directory with .phpqa.yml, @default current working directory
      */
     public function tools(
-         $opts = array(
+        $opts = array(
             'config' => '',
         )
     ) {

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -455,7 +455,7 @@ trait CodeAnalysisTasks
     private function phpunit(RunningTool $tool)
     {
         $args = array();
-        $configFile = $this->config->value('phpunit.config');
+        $configFile = $this->config->path('phpunit.config');
         if ($configFile) {
             $args['configuration'] = $configFile;
         }

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -210,7 +210,7 @@ trait CodeAnalysisTasks
     private function toolToExec(RunningTool $tool)
     {
         $customBinary = $this->config->path("{$tool}.binary");
-        $binary = $customBinary ?: pathToBinary($tool->binary);
+        $binary = $customBinary ? escapePath($customBinary) : pathToBinary($tool->binary);
         $process = $this->taskExec($binary);
         $method = str_replace('-', '', $tool);
         foreach ($this->{$method}($tool) as $arg => $value) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,10 +10,15 @@ class Config
 
     public function __construct()
     {
-        $this->loadCustomConfig(__DIR__ . '/../');
+        $this->loadConfig(__DIR__ . '/../');
     }
 
-    public function loadCustomConfig($directory, $isUserDirectory = false)
+    public function loadUserConfig($directory)
+    {
+        $this->loadConfig($directory ?: getcwd(), $directory);
+    }
+
+    private function loadConfig($directory, $isUserDirectory = false)
     {
         $configDir = $directory . '/';
         $configFile = "{$configDir}.phpqa.yml";
@@ -26,6 +31,12 @@ class Config
         } elseif ($isUserDirectory) {
             $this->throwInvalidPath('.phpqa.yml', $configFile);
         }
+    }
+
+    public function getCustomBinary($tool)
+    {
+        $binary = $this->path("{$tool}.binary");
+        return $binary ? escapePath($binary) : $binary;
     }
 
     public function value($path)

--- a/src/Config.php
+++ b/src/Config.php
@@ -36,7 +36,14 @@ class Config
     public function getCustomBinary($tool)
     {
         $binary = $this->path("{$tool}.binary");
-        return $binary ? escapePath($binary) : $binary;
+        if ($binary) {
+            $filename = basename($binary);
+            if (is_bool(strpos($filename, "{$tool}"))) {
+                throw new \RuntimeException("Invalid '{$tool}' binary ('{$tool}' not found in '{$binary}')");
+            }
+            return escapePath($binary);
+        }
+        return null;
     }
 
     public function value($path)

--- a/src/Options.php
+++ b/src/Options.php
@@ -80,8 +80,11 @@ class Options
         }
     }
 
-    public function buildRunningTools(array $tools)
+    public function buildRunningTools(array $tools, $hasCustomBinary = null)
     {
+        $hasCustomBinary = $hasCustomBinary ?: function () {
+            return false;
+        };
         $allowed = array();
         foreach ($tools as $tool => $config) {
             if (array_key_exists($tool, $this->allowedTools)) {
@@ -90,7 +93,7 @@ class Options
                     'xml' => array_key_exists('xml', $config) ? array_map([$this, 'rawFile'], $config['xml']) : []
                 ];
                 $runningTool = new RunningTool($tool, $preload + $config);
-                if ($runningTool->isInstalled()) {
+                if ($runningTool->isInstalled() || $hasCustomBinary($tool)) {
                     $allowed[$tool] = $runningTool;
                 }
             }

--- a/src/Options.php
+++ b/src/Options.php
@@ -8,8 +8,6 @@ class Options
     private $analyzedDirs;
     /** @var string */
     public $buildDir;
-    /** @var string */
-    public $configDir;
     /** @var IgnoredPaths */
     public $ignore;
     /** @var array */
@@ -45,7 +43,6 @@ class Options
         $this->isSavedToFiles = $options['output'] == 'file';
         $this->isOutputPrinted = $this->isSavedToFiles ? $options['verbose'] : true;
         $this->hasReport = $this->isSavedToFiles ? $options['report'] : false;
-        $this->configDir = $options['config'] ? $options['config'] : getcwd();
     }
 
     public function getCommonRootPath()
@@ -80,11 +77,8 @@ class Options
         }
     }
 
-    public function buildRunningTools(array $tools, $hasCustomBinary = null)
+    public function buildRunningTools(array $tools, Config $phpqaConfig = null)
     {
-        $hasCustomBinary = $hasCustomBinary ?: function () {
-            return false;
-        };
         $allowed = array();
         $skipped = array();
         foreach ($tools as $tool => $config) {
@@ -94,7 +88,7 @@ class Options
                     'xml' => array_key_exists('xml', $config) ? array_map([$this, 'rawFile'], $config['xml']) : []
                 ];
                 $runningTool = new RunningTool($tool, $preload + $config);
-                if ($runningTool->isInstalled() || $hasCustomBinary($tool)) {
+                if ($runningTool->isInstalled() || ($phpqaConfig && $phpqaConfig->getCustomBinary($tool))) {
                     $allowed[$tool] = $runningTool;
                 } else {
                     $skipped[] = $tool;

--- a/src/Options.php
+++ b/src/Options.php
@@ -86,6 +86,7 @@ class Options
             return false;
         };
         $allowed = array();
+        $skipped = array();
         foreach ($tools as $tool => $config) {
             if (array_key_exists($tool, $this->allowedTools)) {
                 $preload = [
@@ -95,10 +96,12 @@ class Options
                 $runningTool = new RunningTool($tool, $preload + $config);
                 if ($runningTool->isInstalled() || $hasCustomBinary($tool)) {
                     $allowed[$tool] = $runningTool;
+                } else {
+                    $skipped[] = $tool;
                 }
             }
         }
-        return $allowed;
+        return array($allowed, $skipped);
     }
 
     public function toFile($file)

--- a/src/Task/TableSummary.php
+++ b/src/Task/TableSummary.php
@@ -20,9 +20,10 @@ class TableSummary
 
     /**
      * @param \Edge\QA\RunningTool[] $usedTools
+     * @param string[] $skippedTools
      * @return int
      */
-    public function __invoke(array $usedTools)
+    public function __invoke(array $usedTools, array $skippedTools)
     {
         $this->writeln('', 'cyan');
         $table = new Table($this->output);
@@ -62,11 +63,14 @@ class TableSummary
         }
         $table->addRow($row);
         $table->render();
-        return $this->result($failedTools);
+        return $this->result($failedTools, $skippedTools);
     }
 
-    private function result(array $failedTools)
+    private function result(array $failedTools, array $skippedTools)
     {
+        if ($skippedTools) {
+            $this->writeln('Not installed tools: <comment>' . implode(', ', $skippedTools) . '</comment>', 'magenta');
+        }
         if ($failedTools) {
             $this->writeln('Failed tools: <comment>' . implode(', ', $failedTools) . '</comment>', 'red');
             return 1;

--- a/tests/.travis/.phpqa.yml
+++ b/tests/.travis/.phpqa.yml
@@ -14,7 +14,8 @@ phpstan:
     standard: phpstan.neon
 
 phpunit:
-    config: phpunit.xml
+    binary: ../../vendor/phpunit/phpunit/phpunit
+    config: ../../phpunit.xml
     reports:
         file:
             log: [junit]

--- a/tests/Config/.phpqa.yml
+++ b/tests/Config/.phpqa.yml
@@ -11,3 +11,11 @@ phpcpd:
 
 # Php file extensions to parse.
 extensions: php,inc,module
+
+# invalid binary
+phpunit:
+    binary: non-existent-binary
+
+# binary for other tool
+phpmetrics:
+    binary: ../../phpqa

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -37,7 +37,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testOverrideDefaultConfig()
     {
         $config = new Config();
-        $config->loadCustomConfig(__DIR__);
+        $config->loadUserConfig(__DIR__);
         assertThat($config->value('phpcpd.minLines'), is(5));
         assertThat($config->value('phpcpd.minTokens'), is(70));
         assertThat($config->value('phpcs.standard'), is('Zend'));
@@ -49,13 +49,13 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $directoryWithoutConfig = __DIR__ . '/../';
         $config = new Config();
         $this->shouldStopPhpqa();
-        $config->loadCustomConfig($directoryWithoutConfig, true);
+        $config->loadUserConfig($directoryWithoutConfig);
     }
 
     public function testThrowExceptionWhenFileDoesNotExist()
     {
         $config = new Config();
-        $config->loadCustomConfig(__DIR__);
+        $config->loadUserConfig(__DIR__);
         $this->shouldStopPhpqa();
         $config->path('phpcs.standard');
     }
@@ -63,9 +63,15 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testConfigCsvString()
     {
         $config = new Config();
-        $config->loadCustomConfig(__DIR__);
+        $config->loadUserConfig(__DIR__);
         $extensions = $config->csv('extensions');
         assertThat($extensions, equalTo('php,inc,module'));
+    }
+
+    public function testUseCwdIfNoDirectoryIsSpecified()
+    {
+        $config = new Config();
+        $config->loadUserConfig('');
     }
 
     private function shouldStopPhpqa()

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -74,6 +74,22 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config->loadUserConfig('');
     }
 
+    public function testThrowExceptionWhenBinaryDoesNotExist()
+    {
+        $config = new Config();
+        $config->loadUserConfig(__DIR__);
+        $this->shouldStopPhpqa();
+        $config->getCustomBinary('phpunit');
+    }
+
+    public function testThrowExceptionWhenWrongBinaryIsUsed()
+    {
+        $config = new Config();
+        $config->loadUserConfig(__DIR__);
+        $this->shouldStopPhpqa();
+        $config->getCustomBinary('phpmetrics');
+    }
+
     private function shouldStopPhpqa()
     {
         $this->setExpectedException('Exception');

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -43,15 +43,15 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     public function testIgnorePdependInCliOutput()
     {
         $cliOutput = $this->overrideOptions(array('output' => 'cli'));
-        assertThat($this->fileOutput->buildRunningTools(array('pdepend' => [])), is(nonEmptyArray()));
-        assertThat($cliOutput->buildRunningTools(array('pdepend' => [])), is(emptyArray()));
+        assertThat($this->buildRunningTools($this->fileOutput, array('pdepend' => [])), is(nonEmptyArray()));
+        assertThat($this->buildRunningTools($cliOutput, array('pdepend' => [])), is(emptyArray()));
     }
 
     public function testIgnoreNotInstalledTool()
     {
         assertThat(
             $this->fileOutput->buildRunningTools(array('pdepend' => ['internalClass' => 'UnknownTool\UnknownClass'])),
-            is(emptyArray())
+            is([[], ['pdepend']])
         );
     }
 
@@ -132,8 +132,13 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     public function testLoadAllowedErrorsCount()
     {
         $options = $this->overrideOptions(array('tools' => 'phpcs:1,pdepend'));
-        $tools = $options->buildRunningTools(array('phpcs' => [], 'pdepend' => []));
+        $tools = $this->buildRunningTools($options, array('phpcs' => [], 'pdepend' => []));
         assertThat($tools['phpcs']->getAllowedErrorsCount(), is(1));
         assertThat($tools['pdepend']->getAllowedErrorsCount(), is(nullValue()));
+    }
+
+    private function buildRunningTools(Options $o, array $tools)
+    {
+        return $o->buildRunningTools($tools)[0];
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -55,21 +55,6 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /** @dataProvider provideConfig */
-    public function testLoadDirectoryWithCustomConfig($config, $expectedConfig)
-    {
-        $options = $this->overrideOptions(array('config' => $config));
-        assertThat($options->configDir, is($expectedConfig));
-    }
-
-    public function provideConfig()
-    {
-        return array(
-            'cwd when config is not defined' => array('', getcwd()),
-            'use passed config (relative to cwd)' => array('path-to-config-directory', 'path-to-config-directory')
-        );
-    }
-
     /** @dataProvider provideOutputs */
     public function testBuildOutput(array $opts, $isSavedToFiles, $isOutputPrinted, $hasReport)
     {


### PR DESCRIPTION
Closes https://github.com/EdgedesignCZ/phpqa/issues/88

- [x] custom PHPUnit binary (or any other tool) - allow spaces, validate tool name (prevent using `phploc` in `phpunit.binary`)
- [x] show [skipped tools in summary](https://travis-ci.org/EdgedesignCZ/phpqa/jobs/278929601#L417)
- [x] load corrent version in `phpqa tools` + refactoring printing versions (_same format for console versions_)
- [x] **`phpunit.config` BC** - `phpunit.config` is relative to `.phpqa.yml`, previously it was relative to `cwd`
- [x] documentation, ...