### PR TITLE
Refine vimeo/psalm integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 phpstan-phpqa.neon
 .php_cs
 .php_cs.cache
-psalm-config.xml
+psalm-phpqa.xml

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ phpmetrics | [phpmetrics.html (v1)](https://edgedesigncz.github.io/phpqa/report/
 php-cs-fixer | [php-cs-fixer.html](https://edgedesigncz.github.io/phpqa/report/php-cs-fixer.html) | [✓](http://cs.sensiolabs.org/#usage "txt output format") |
 parallel-lint | [parallel-lint.html](https://edgedesigncz.github.io/phpqa/report/parallel-lint.html) | [✓](https://github.com/JakubOnderka/PHP-Parallel-Lint#example-output) |
 phpstan | [phpstan.html](https://edgedesigncz.github.io/phpqa/report/phpstan.html), [phpstan-phpqa.neon](https://edgedesigncz.github.io/phpqa/report/phpstan-phpqa.neon) | [✓](https://edgedesigncz.github.io/phpqa/report/phpstan.html), [phpstan-phpqa.neon](https://edgedesigncz.github.io/phpqa/report/phpstan-phpqa.neon "Generated configuration is saved in current working directory") |
-psalm | [psalm.html](https://edgedesigncz.github.io/phpqa/report/psalm.html), [psalm.xml](https://edgedesigncz.github.io/phpqa/report/psalm.xml), [psalm-config.xml](https://edgedesigncz.github.io/phpqa/report/psalm-config.xml) | [✓](https://edgedesigncz.github.io/phpqa/report/psalm.xml), [psalm-config.xml](https://edgedesigncz.github.io/phpqa/report/psalm-config.xml "Generated configuration is saved in current working directory") |
+psalm | [psalm.html](https://edgedesigncz.github.io/phpqa/report/psalm.html), [psalm.xml](https://edgedesigncz.github.io/phpqa/report/psalm.xml), [psalm-phpqa.xml](https://edgedesigncz.github.io/phpqa/report/psalm-phpqa.xml) | [✓](https://edgedesigncz.github.io/phpqa/report/psalm.xml), [psalm-phpqa.xml](https://edgedesigncz.github.io/phpqa/report/psalm-phpqa.xml "Generated configuration is saved in current working directory") |
 
 ## Exit code
 

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -480,7 +480,7 @@ trait CodeAnalysisTasks
                     'includes' => $this->options->getAnalyzedDirs(),
                     'excludes' => $this->options->ignore->psalm()
                 )
-            );    
+            );
         } else {
             $psalmXml = file_get_contents($this->config->path('psalm.config'));
         }

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -493,9 +493,10 @@ trait CodeAnalysisTasks
             'config' => escapePath($psalmFile),
             'output-format' => $this->options->isOutputPrinted?'console':'emacs',
             'show-info' => $this->config->value('psalm.showInfo')?'true':'false',
-            'report' => escapePath($this->options->rawFile('psalm.xml'))
         );
-
+        if ($this->options->isSavedToFiles) {
+            $args['report'] = $this->options->toFile('psalm.xml');
+        }
         if ($this->config->value('psalm.deadCode')) {
             $args['find-dead-code'] = '';
         }

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -491,8 +491,7 @@ trait CodeAnalysisTasks
 
         $args = array(
             'config' => escapePath($psalmFile),
-            'output-format' => $this->options->isOutputPrinted?'console':'emacs',
-            'show-info' => $this->config->value('psalm.showInfo')?'true':'false',
+            'show-info' => $this->config->value('psalm.showInfo') ? 'true' : 'false',
         );
         if ($this->options->isSavedToFiles) {
             $args['report'] = $this->options->toFile('psalm.xml');

--- a/src/CodeAnalysisTasks.php
+++ b/src/CodeAnalysisTasks.php
@@ -472,27 +472,25 @@ trait CodeAnalysisTasks
 
     private function psalm()
     {
-        $psalmConfigFile = escapePath($this->config->path('psalm.config'));
         if (!$this->config->value('psalm.config')) {
-            $psalmConfigDir = rtrim($this->options->isSavedToFiles ? $this->options->rawFile('') : getcwd(), '/');
-            $psalmConfigFile = "{$psalmConfigDir}/psalm-config.xml";
-
             $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__.'/../app/'));
-            file_put_contents(
-                $psalmConfigFile,
-                $twig->render(
-                    'psalm.xml.twig',
-                    array(
-                        'includes' => $this->options->getAnalyzedDirs(),
-                        'excludes' => $this->options->ignore->psalm()
-                    )
+            $psalmXml = $twig->render(
+                'psalm.xml.twig',
+                array(
+                    'includes' => $this->options->getAnalyzedDirs(),
+                    'excludes' => $this->options->ignore->psalm()
                 )
-            );
-            $psalmConfigFile = escapePath($psalmConfigFile);
+            );    
+        } else {
+            $psalmXml = file_get_contents($this->config->path('psalm.config'));
         }
 
+        $psalmDir = rtrim($this->options->isSavedToFiles ? $this->options->rawFile('') : getcwd(), '/');
+        $psalmFile = "{$psalmDir}/psalm-phpqa.xml";
+        file_put_contents($psalmFile, $psalmXml);
+
         $args = array(
-            'config' => $psalmConfigFile,
+            'config' => escapePath($psalmFile),
             'output-format' => $this->options->isOutputPrinted?'console':'emacs',
             'show-info' => $this->config->value('psalm.showInfo')?'true':'false',
             'report' => escapePath($this->options->rawFile('psalm.xml'))


### PR DESCRIPTION
https://github.com/EdgedesignCZ/phpqa/pull/87, https://github.com/EdgedesignCZ/phpqa/commit/b4094d94825931530556e1528a7ceea2a1f09fbe

- [x] [update documentation](https://github.com/EdgedesignCZ/phpqa/commit/c42d8cc0ebf1f37f3ce366c39348125bfa923821)
- [x] `psalm-phpqa.xml` must be always created (originally `psalm-config.xml`)
- [x] `psalm.xml` should not be created in `--output cli`
- [x] is `--output-format` necessary? I've got same results with `emacs` (_why emacs?_) and no `--output-format`