### PR TITLE
CI - fix psalm errors detected in v0.3.72

### DIFF
--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./phpqa --verbose --report --config tests/.travis --tools phpcs:0,php-cs-fixer:0,phpmd:0,phpcpd:0,parallel-lint:0,phpstan:0,phpmetrics:0,phploc,pdepend,phpunit:0,psalm:4,security-checker:0
+./phpqa --verbose --report --config tests/.travis --tools phpcs:0,php-cs-fixer:0,phpmd:0,phpcpd:0,parallel-lint:0,phpstan:0,phpmetrics:0,phploc,pdepend,phpunit:0,psalm:0,security-checker:0

--- a/tests/.travis/psalm.xml
+++ b/tests/.travis/psalm.xml
@@ -32,12 +32,23 @@
           <errorLevel type="info">
             <file name="src/CodeAnalysisTasks.php" />
             <file name="src/Tools/Tool.php" />
+            <file name="src/Tools/Tools.php" />
             <file name="src/RunningTool.php" />
           </errorLevel>
           <errorLevel type="suppress"> 
             <directory name="tests" />
           </errorLevel> 
         </PossiblyUnusedMethod>
+        <InvalidReturnType>
+          <errorLevel type="info">
+            <file name="src/Task/ParallelExec.php" />
+          </errorLevel>
+        </InvalidReturnType>
+        <UnresolvableInclude>
+          <errorLevel type="info">
+            <file name="src/Tools/Analyzer/PhpcsV3.php" />
+          </errorLevel>
+        </UnresolvableInclude>
         <DeprecatedMethod errorLevel="info" /> 
 
         <!-- Ignored rules -->
@@ -48,10 +59,10 @@
         <MissingClosureReturnType errorLevel="suppress" />
         <MissingConstructor errorLevel="suppress" />
         <UntypedParam errorLevel="suppress" />
+        <PossiblyUnusedParam errorLevel="info" />
 
         <!-- false positive -->
         <UnusedVariable errorLevel="info" />
-        <PossiblyUnusedVariable errorLevel="info" />
         <UndefinedThisPropertyAssignment errorLevel="info" />
         <TooFewArguments> 
           <errorLevel type="info"> 


### PR DESCRIPTION
https://travis-ci.org/EdgedesignCZ/phpqa/jobs/324309595#L878

```
Fatal error: Uncaught Psalm\Exception\ConfigException: Error parsing file /home/travis/build/EdgedesignCZ/phpqa/ on line 48: Element 'PossiblyUnusedVariable': This element is not expected.
 in /home/travis/build/EdgedesignCZ/phpqa/vendor/vimeo/psalm/src/Psalm/Config.php:260
Stack trace:
#0 /home/travis/build/EdgedesignCZ/phpqa/vendor/vimeo/psalm/src/Psalm/Config.php(218): Psalm\Config::loadFromXML('/home/travis/bu...', '/home/travis/bu...', '<?xml version="...')
#1 /home/travis/build/EdgedesignCZ/phpqa/vendor/vimeo/psalm/src/Psalm/Checker/ProjectChecker.php(1757): Psalm\Config::loadFromXMLFile('/home/travis/bu...', '/home/travis/bu...')
#2 /home/travis/build/EdgedesignCZ/phpqa/vendor/vimeo/psalm/src/psalm.php(390): Psalm\Checker\ProjectChecker->setConfigXML('/home/travis/bu...', '/home/travis/bu...')
#3 /home/travis/build/EdgedesignCZ/phpqa/vendor/vimeo/psalm/psalm(2): require_once('/home/travis/bu...')
#4 {main}
  thrown in /home/travis/build/EdgedesignCZ/phpqa/vendor/vimeo/psalm/src/Psalm/Config.php on line 260
```

PossiblyUnusedVariable
https://github.com/vimeo/psalm/commit/875bb8c072ce1228c8f12518f3bf38dc365da5fd#diff-52926e4f815aeddeeac38218c09784f5

MissingPropertyDeclaration
https://github.com/vimeo/psalm/commit/81493a639e5dc6749f9d0aeb0c86a1777f530bd9#diff-52926e4f815aeddeeac38218c09784f5

https://github.com/EdgedesignCZ/phpqa/pull/99