### PR TITLE
v4.* of symfony/process requires PHP7.1.3 or greater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phploc/phploc": "*",
         "symfony/dependency-injection": ">=2.8",
         "symfony/filesystem": ">=2.8",
-        "symfony/process": ">=2.8",
+        "symfony/process": ">=2.8 ~3.4",
         "symfony/finder": ">=2.8",
         "symfony/yaml": ">=2.8",
         "twig/twig": "~1|~2",


### PR DESCRIPTION
Breaks on fresh install of phpqa with anything less:

```
$ composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for symfony/process v4.0.2 -> satisfiable by symfony/process[v4.0.2].
    - symfony/process v4.0.2 requires php ^7.1.3 -> your PHP version (7.0.26) does not satisfy that requirement.
  Problem 2
    - symfony/process v4.0.2 requires php ^7.1.3 -> your PHP version (7.0.26) does not satisfy that requirement.
    - edgedesign/phpqa v1.16.0 requires symfony/process >=2.8 -> satisfiable by symfony/process[v4.0.2].
    - Installation request for edgedesign/phpqa v1.16.0 -> satisfiable by edgedesign/phpqa[v1.16.0].
```