### PR TITLE
Parallel lint - add support for extensions

### DIFF
--- a/src/Tools/Analyzer/ParallelLint.php
+++ b/src/Tools/Analyzer/ParallelLint.php
@@ -17,6 +17,7 @@ class ParallelLint extends \Edge\QA\Tools\Tool
     {
         return array(
             $this->options->ignore->parallelLint(),
+            "-e {$this->config->csv('extensions')}",
             $this->options->getAnalyzedDirs(' '),
         );
     }


### PR DESCRIPTION
closes #104

```
$ vendor/bin/parallel-lint --help
PHP Parallel Lint version 0.9.1
-------------------------------
Usage:
    parallel-lint [sa] [-p php] [-e ext] [-j num] [--exclude dir] [files or directories]

Options:
    -e <ext>        Check only files with selected extensions separated by comma.
                    (default: php,php3,php4,php5,phtml)
```