### PR TITLE
Dev do not pass nondirs to psalm

### DIFF
--- a/src/Tools/Analyzer/PhpMetricsV2.php
+++ b/src/Tools/Analyzer/PhpMetricsV2.php
@@ -20,13 +20,6 @@ class PhpMetricsV2 extends \Edge\QA\Tools\Tool
             $args['report-html'] = $this->options->toFile('phpmetrics/');
             $args['report-violations'] = $this->options->toFile('phpmetrics.xml');
         }
-        if ($git = $this->config->value('phpmetrics.git')) {
-            if (is_bool($git)) {
-                $args[] = '--git';
-            } else {
-                $args['git'] = $git;
-            }
-        }
         $args[] = $this->options->getAnalyzedDirs(',');
         return $args;
     }

--- a/src/Tools/Analyzer/PhpMetricsV2.php
+++ b/src/Tools/Analyzer/PhpMetricsV2.php
@@ -20,6 +20,13 @@ class PhpMetricsV2 extends \Edge\QA\Tools\Tool
             $args['report-html'] = $this->options->toFile('phpmetrics/');
             $args['report-violations'] = $this->options->toFile('phpmetrics.xml');
         }
+        if ($git = $this->config->value('phpmetrics.git')) {
+            if (is_bool($git)) {
+                $args[] = '--git';
+            } else {
+                $args['git'] = $git;
+            }
+        }
         $args[] = $this->options->getAnalyzedDirs(',');
         return $args;
     }

--- a/src/Tools/Analyzer/Psalm.php
+++ b/src/Tools/Analyzer/Psalm.php
@@ -54,6 +54,9 @@ class Psalm extends \Edge\QA\Tools\Tool
         }
 
         foreach ($this->options->getAnalyzedDirs() as $dir) {
+            if (!is_dir($dir)) {
+                continue;
+            }
             $xml->projectFiles
                 ->addChild('directory')
                 ->addAttribute('name', trim($dir, '"'));


### PR DESCRIPTION
When analyzing a dir `src/`, phpmetrics does not detect `composer.json` (which is ok, since the file is in the directory above, `src/../`.

However, phpmetrics can be easily fooled to take composer.json into account, by specifying it in `analyzeDirs` - which is not clean, but it works (WORKAROUND - as mentioned later in this comment).

But when you do that, psalm fails, because it blindly takes everything which is not a dir into its own configuration.

This PR fixes psalm to make the workaround described above possible.

It's a clean fix, regardless of that fact that the workaround is a hack, because the generated psalm xml config is semantically correct with this patch applied: `<directory ...` are indeed directories.