### PR TITLE
Keep tools order from --tools option

### DIFF
--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./phpqa --verbose --report --config tests/.travis --tools phpcs:0,php-cs-fixer:0,phpmd:0,phpcpd:0,parallel-lint:0,phpstan:0,phpmetrics:0,phploc,pdepend,phpunit:0,psalm,security-checker:0
+./phpqa --verbose --report --config tests/.travis --tools phpmetrics:0,phploc,phpcs:0,php-cs-fixer:0,phpmd:0,pdepend,phpcpd:0,phpstan:0,phpunit:0,psalm,security-checker:0,parallel-lint:0

--- a/src/Options.php
+++ b/src/Options.php
@@ -94,6 +94,18 @@ class Options
                 $allowed[$tool] = $runningTool;
             }
         }
+        return $this->sortTools($allowed);
+    }
+
+    private function sortTools(array $allowed)
+    {
+        $keys = array_keys($this->allowedTools);
+        uksort(
+            $allowed,
+            function ($a, $b) use ($keys) {
+                return array_search($a, $keys) - array_search($b, $keys);
+            }
+        );
         return $allowed;
     }
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -40,6 +40,13 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         assertThat($this->fileOutput->rawFile('file'), is('build//file'));
     }
 
+    public function testRespectToolsOrderDefinedInOption()
+    {
+        $cliOutput = $this->overrideOptions(['output' => 'cli', 'tools' => 'phpunit,phpmetrics']);
+        $tools = $this->buildRunningTools($cliOutput, ['phpmetrics' => [], 'phpunit' => []]);
+        assertThat(array_keys($tools), is(['phpunit', 'phpmetrics']));
+    }
+
     public function testIgnorePdependInCliOutput()
     {
         $cliOutput = $this->overrideOptions(array('output' => 'cli'));


### PR DESCRIPTION
Necessary when tool A is using artifacts from tool B.
Of course non-parallel execution must be used (`--execution no-parallel`).

E.g. phpmetrics uses junit log from phpunit
https://github.com/EdgedesignCZ/phpqa/pull/128