### PR TITLE
Fix displaying psalm issue line numbers

### DIFF
--- a/app/report/psalm.xsl
+++ b/app/report/psalm.xsl
@@ -36,8 +36,8 @@
                     <xsl:value-of select="message/text()" /><br />
                     <span class="text-muted"><xsl:value-of select="type/text()" /></span>
                 </td>
-                <td><xsl:value-of select="line_number" /></td>
-                <td><xsl:value-of select="column" /></td>
+                <td><xsl:value-of select="line_from" /></td>
+                <td><xsl:value-of select="line_to" /></td>
             </tr>
             <tr style="display:none">
                 <xsl:attribute name="id">
@@ -203,8 +203,8 @@
                                                 Only errors
                                             </label>
                                         </th>
-                                        <th>Line</th>
-                                        <th>Column</th>
+                                        <th>Line From</th>
+                                        <th>Line To</th>
                                     </tr>
                                 </thead>
                                 <xsl:for-each select="//item[file_name[not(preceding::file_name/. = .)]]">


### PR DESCRIPTION
Psalm seems to have changed the schema of it's xml report. Instead of containing `line_number` and `column` it now has `line_to` and `line_from`, which means we currently get a html report that looks like:

![2018-08-06_14-54-13](https://user-images.githubusercontent.com/2062388/43697718-5250ab72-9989-11e8-83dd-c6e3adcdd3e7.png)

This update shows the line numbers like:

![2018-08-06_14-53-25](https://user-images.githubusercontent.com/2062388/43697722-5c86aba0-9989-11e8-8991-42c5fa014322.png)
