### PR TITLE
fix(phpstan): use error-format instead of errorFormat

### DIFF
--- a/src/Tools/Analyzer/Phpstan.php
+++ b/src/Tools/Analyzer/Phpstan.php
@@ -52,7 +52,7 @@ class Phpstan extends \Edge\QA\Tools\Tool
         return array(
             'analyze',
             'ansi' => '',
-            'errorFormat' => 'checkstyle',
+            'error-format' => 'checkstyle',
             'level' => $this->config->value('phpstan.level'),
             'configuration' => $neonFile,
             $this->options->getAnalyzedDirs(' '),


### PR DESCRIPTION
In [0.10.3](https://github.com/phpstan/phpstan/releases/tag/0.10.3) PhpStan deprecated `--errorFormat` in favour of `--error-format`.

This has now been removed in the [latest version](https://github.com/phpstan/phpstan/commit/12545aca186fe3858a88ee49494c4a589845773c#diff-e75a2e4bb0a265ea1c924c592e791e10).

This pull requests updates the generated parameters to use the new parameter.