### PR TITLE
Support Psalm 3.x

### DIFF
--- a/src/Tools/Analyzer/Psalm.php
+++ b/src/Tools/Analyzer/Psalm.php
@@ -12,7 +12,10 @@ class Psalm extends \Edge\QA\Tools\Tool
         'xml' => ['psalm.xml'],
         'errorsXPath' => '//item/severity[text()=\'error\']',
         'composer' => 'vimeo/psalm',
-        'internalClass' => 'Psalm\Checker\ProjectChecker',
+        'internalClass' => [
+            'Psalm\Checker\ProjectChecker', // Psalm < 3.x
+            'Psalm\Internal\Analyzer\ProjectAnalyzer', // Psalm > 3.x
+        ]
     );
 
     public function __invoke()


### PR DESCRIPTION
In Psalm 3.x, ProjectChecker was changed to ProjectAnalyzer. Changing this seemed to be fine for me otherwise, it seemed to process the errors properly, so it must have been largely just a name change /shrug