### PR TITLE
Fix executing php-cs-fixer w/o path if config file given

### DIFF
--- a/src/Tools/Analyzer/PhpCsFixer.php
+++ b/src/Tools/Analyzer/PhpCsFixer.php
@@ -18,9 +18,7 @@ class PhpCsFixer extends \Edge\QA\Tools\Tool
     public function __invoke()
     {
         $configFile = $this->config->value('php-cs-fixer.config');
-        if ($configFile) {
-            $analyzedDir = $this->options->getAnalyzedDirs(' ');
-        } else {
+        if (!$configFile) {
             $analyzedDirs = $this->options->getAnalyzedDirs();
             $analyzedDir = reset($analyzedDirs);
             if (count($analyzedDirs) > 1) {
@@ -33,17 +31,20 @@ class PhpCsFixer extends \Edge\QA\Tools\Tool
         }
         $args = [
             'fix',
-            $analyzedDir,
             'verbose' => '',
             'format' => $this->options->isSavedToFiles ? 'junit' : 'txt',
         ];
         if ($configFile) {
             $args['config'] = $configFile;
         } else {
-            $args += [
-                'rules' => $this->config->value('php-cs-fixer.rules'),
-                'allow-risky' => $this->config->value('php-cs-fixer.allowRiskyRules') ? 'yes' : 'no',
-            ];
+            $args = array_merge(
+                $args,
+                [
+                    $analyzedDir,
+                    'rules' => $this->config->value('php-cs-fixer.rules'),
+                    'allow-risky' => $this->config->value('php-cs-fixer.allowRiskyRules') ? 'yes' : 'no',
+                ]
+            );
         }
         if ($this->config->value('php-cs-fixer.isDryRun')) {
             $args['dry-run'] = '';


### PR DESCRIPTION
Taking this statement 

> By default --path-mode is set to override, which means, that if you specify the path to a file or a directory via command arguments, then the paths provided to a Finder in config file will be ignored.

from php-cs-fixer documentation into account, your path setting from config file won't be applied if called with path argument at the same time. As phpqa always applied the --analyzedDirs values as path argument, config file was always omitted.