### PR TITLE
Add support for multiple phpmd rulesets

### DIFF
--- a/.phpqa.yml
+++ b/.phpqa.yml
@@ -26,6 +26,7 @@ php-cs-fixer:
 
 phpmd:
     allowedErrorsCount: null
+    # alternatively you can use an array to define multiple rule sets (https://phpmd.org/documentation/index.html#using-multiple-rule-sets)
     standard: app/phpmd.xml
 
 pdepend:

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Tool | Settings | Default Value | Your value
 [phpmetrics.junit](https://github.com/EdgedesignCZ/phpqa/pull/125) | phpmetrics v2 evaluates metrics according to JUnit logs | `null` | Path to JUnit xml
 [phpmetrics.composer](https://github.com/EdgedesignCZ/phpqa/pull/123) | phpmetrics v2 analyzes composer dependencies | `null` | Path to composer.json when the file is not included in `analyzedDirs`
 [pdepend.coverageReport](https://github.com/EdgedesignCZ/phpqa/pull/124) | Load Clover style CodeCoverage report | `null` | Path to report produced by PHPUnit's `--coverage-clover` option
-[phpmd](http://phpmd.org/documentation/creating-a-ruleset.html) | Ruleset | [Edgedesign's standard](/app/phpmd.xml) | Path to ruleset
+[phpmd.standard](http://phpmd.org/documentation/creating-a-ruleset.html) | Ruleset | [Edgedesign's standard](/app/phpmd.xml) | Path to ruleset. To specify [multiple rule sets](https://phpmd.org/documentation/index.html#using-multiple-rule-sets), you can use an array
 [phpcpd](https://github.com/sebastianbergmann/phpcpd/blob/de9056615da6c1230f3294384055fa7d722c38fa/src/CLI/Command.php#L136) | Minimum number of lines/tokens for copy-paste detection | 5 lines, 70 tokens |
 [phpstan](https://github.com/phpstan/phpstan#configuration) | Level, config file | Level 0, `%currentWorkingDirectory%/phpstan.neon` | Take a look at [phpqa config in tests/.travis](/tests/.travis/) |
 [phpunit.binary](https://github.com/EdgedesignCZ/phpqa/blob/4947416/.phpqa.yml#L40) | Phpunit binary  | phpqa's phpunit | Path to phpunit executable in your project, typically [`vendor/bin/phpunit`](https://gitlab.com/costlocker/integrations/blob/master/basecamp/backend/.phpqa.yml#L2) |

--- a/src/Config.php
+++ b/src/Config.php
@@ -89,6 +89,22 @@ class Config
         );
     }
 
+    public function pathsOrValues($path)
+    {
+        return $this->get(
+            $path,
+            function ($values, $dir) {
+                return array_map(
+                    function ($pathOrValue) use ($dir) {
+                        $realpath = realpath("{$dir}{$pathOrValue}");
+                        return $realpath ? $realpath : $pathOrValue;
+                    },
+                    (array) $values
+                );
+            }
+        );
+    }
+
     public function csv($path)
     {
         return $this->get(

--- a/src/Tools/Analyzer/Phpmd.php
+++ b/src/Tools/Analyzer/Phpmd.php
@@ -13,10 +13,12 @@ class Phpmd extends \Edge\QA\Tools\Tool
 
     public function __invoke()
     {
+        $rulesets = $this->config->pathsOrValues('phpmd.standard');
+
         $args = array(
             $this->options->getAnalyzedDirs(','),
             $this->options->isSavedToFiles ? 'xml' : 'text',
-            \Edge\QA\escapePath($this->config->path('phpmd.standard')),
+            \Edge\QA\escapePath(implode(',', $rulesets)),
             $this->options->ignore->phpmd(),
             'suffixes' => $this->config->csv('extensions')
         );


### PR DESCRIPTION
Hi!

Currently, the .phpqa file only allows to specify one PHPMD ruleset, whereas phpmd allows to specify multiple rulesets.

For example: `bin/phpmd src/ xml cleancode,codesize,design,naming,unusedcode --suffixes php`

This PR adds support for specifying multiple rulesets, and preserves backwards-compatibility.
To allow specifying default rulesets (e.g. `unusedcode`), I also removed the call to the `path` function.

The following configurations would all work:

```yml
phpmd:
    standard: vendor/path/to/a/ruleset.xml
```

```yml
phpmd:
    standard:
        - vendor/path/to/a/ruleset.xml
        - vendor/path/to/another/ruleset.xml
```

```yml
phpmd:
    standard:
        - cleancode
        - codesize
        - design
        - naming
        - unusedcode
```
