### PR TITLE
Travis - fix security-checker (symfony/dependency-injection vulnerability)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "consolidation/robo": "~0|~1",
         "phpmd/phpmd" : "*",
         "phploc/phploc": "*",
-        "symfony/dependency-injection": ">=2.8",
+        "symfony/dependency-injection": ">=2.8.50",
         "symfony/filesystem": ">=2.8",
         "symfony/process": ">=2.8",
         "symfony/finder": ">=2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0632ce5fb57abb8104bab4debdd6e32",
+    "content-hash": "ae0ce738f9571a5ca20d1bc81edf2e81",
     "packages": [
         {
             "name": "consolidation/robo",
@@ -1361,16 +1361,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.8.4",
+            "version": "v2.8.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "f7b4a498e679fa440b16facb934680a1527ed48c"
+                "reference": "c306198fee8f872a8f5f031e6e4f6f83086992d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f7b4a498e679fa440b16facb934680a1527ed48c",
-                "reference": "f7b4a498e679fa440b16facb934680a1527ed48c",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/c306198fee8f872a8f5f031e6e4f6f83086992d8",
+                "reference": "c306198fee8f872a8f5f031e6e4f6f83086992d8",
                 "shasum": ""
             },
             "require": {
@@ -1382,10 +1382,11 @@
             "require-dev": {
                 "symfony/config": "~2.2|~3.0.0",
                 "symfony/expression-language": "~2.6|~3.0.0",
-                "symfony/yaml": "~2.1|~3.0.0"
+                "symfony/yaml": "~2.3.42|~2.7.14|~2.8.7|~3.0.7"
             },
             "suggest": {
                 "symfony/config": "",
+                "symfony/expression-language": "For using expressions in service container configuration",
                 "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
                 "symfony/yaml": ""
             },
@@ -1419,7 +1420,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-21T07:27:21+00:00"
+            "time": "2019-04-16T11:33:46+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2441,6 +2442,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {


### PR DESCRIPTION
https://travis-ci.org/EdgedesignCZ/phpqa/jobs/527335745

```
symfony/dependency-injection (v2.8.4)
-------------------------------------
 * [CVE-2019-10910][]: Check service IDs are valid
[CVE-2019-10910]: https://symfony.com/cve-2019-10910
```