### PR TITLE
phpstan - fix supporting v0.12

### DIFF
--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -16,7 +16,7 @@ then
         composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan:~0.8.0 friendsofphp/php-cs-fixer:~2.2 vimeo/psalm:~1 sensiolabs/security-checker:~5 $requireMode
     else
         # symfony 3
-        composer require jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan-src friendsofphp/php-cs-fixer:~2.2 vimeo/psalm sensiolabs/security-checker
+        composer require jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm sensiolabs/security-checker
     fi
 else
     echo "Removing suggested tools"

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -16,7 +16,7 @@ then
         composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan:~0.8.0 friendsofphp/php-cs-fixer:~2.2 vimeo/psalm:~1 sensiolabs/security-checker:~5 $requireMode
     else
         # symfony 3
-        composer require jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan friendsofphp/php-cs-fixer:~2.2 vimeo/psalm sensiolabs/security-checker
+        composer require jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan-src friendsofphp/php-cs-fixer:~2.2 vimeo/psalm sensiolabs/security-checker
     fi
 else
     echo "Removing suggested tools"


### PR DESCRIPTION
> https://travis-ci.org/EdgedesignCZ/phpqa/jobs/621966705#L876
> PHP Fatal error:  Uncaught Error: Class 'Nette\Neon\Neon' not found in src/Tools/Analyzer/Phpstan.php:32

v0.12 distributes phpstan in phar
https://github.com/phpstan/phpstan/releases/tag/0.12.0

~~Installing source repo should be fine. I'm not sure if `internalClass` detection would work with phar _(probably yes, phpqa tools works in CI)_. It can be fixed later...~~

> https://travis-ci.org/EdgedesignCZ/phpqa/jobs/621970707#L791
>  [InvalidArgumentException]                                                   
>  Could not find a matching version of package phpstan/phpstan-src. Check the package spelling, your version constraint and that the package is available in a stability which matches your minimum-stability (stable).