### PR TITLE
Update suggested tools from jakub-onderka to php-parallel-lint

### DIFF
--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -13,12 +13,12 @@ then
     echo "Installing suggested tools"
     if [ ! -z "$requireMode" ]; then
         # docker build OR travis + php 7.0 OR symfony2 (default composer.lock)
-        composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan:~0.12.0 nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm:~1 sensiolabs/security-checker:~5 $requireMode 
+        composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan:~0.12.0 nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm:~1 sensiolabs/security-checker:~5 $requireMode 
     else
         # symfony 3
-        composer require jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm sensiolabs/security-checker
+        composer require php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm sensiolabs/security-checker
     fi
 else
     echo "Removing suggested tools"
-    composer remove jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan friendsofphp/php-cs-fixer vimeo/psalm sensiolabs/security-checker
+    composer remove php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan friendsofphp/php-cs-fixer vimeo/psalm sensiolabs/security-checker
 fi


### PR DESCRIPTION
Composer complaints about `jakub-onderka/*` packages being abandoned:
~~~
Package jakub-onderka/php-parallel-lint is abandoned, you should avoid using it. Use php-parallel-lint/php-parallel-lint instead.
Package jakub-onderka/php-console-color is abandoned, you should avoid using it. Use php-parallel-lint/php-console-color instead.
Package jakub-onderka/php-console-highlighter is abandoned, you should avoid using it. Use php-parallel-lint/php-console-highlighter instead.
~~~

This PR should fix it.