### PR TITLE
#205 - Bumps consolidation/robo to ~2, and handle symfony/process>3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.4",
         "ext-xsl": "*",
-        "consolidation/robo": "~0.5|~1",
+        "consolidation/robo": "~0.5|~1|~2",
         "phpmd/phpmd" : "*",
         "phploc/phploc": "*",
         "symfony/dependency-injection": ">=2.8.50",

--- a/src/Tools/GetVersions.php
+++ b/src/Tools/GetVersions.php
@@ -131,6 +131,12 @@ class GetVersions
 
     private function loadVersionFromConsoleCommand($command)
     {
+        // Since symfony/process 5.x, Process' constructor argument $command is typed as array and
+        // setCommandLine has been removed since then, easy way to detect if symfony/process > 5.0.0
+        if (!method_exists('Symfony\\Component\\Process\\Process', 'setCommandLine')) {
+            $command = [$command];
+        }
+
         $process = new Process($command);
         $process->run();
         $firstLine = $this->getFirstLine($process->getOutput());


### PR DESCRIPTION
Hi folks,

Here's an attempt to bring Symfony 5 compat to phpqa without having to clone it in a separate dir (which worked well btw) or using a commited robo.phar

As I'm not sure at all if it's the proper way to fix this (it sounds like a workaround), or your contribution process itself, I'll be waiting your feedbacks :) 

_Btw, we are still supporting php>5.4, robo 0.x and symfony 2.8, is it still necessary ? maybe it would be simpler to maintain & cleaner to just bumps everything to at least maintained version  (like PHP 7.x, SF 4.x & so on) ? Would it be something we should start working on ?_

Thanks, see ya :) 