### PR TITLE
Allow the parsing of composer 2 installed.json

### DIFF
--- a/src/Tools/GetVersions.php
+++ b/src/Tools/GetVersions.php
@@ -41,8 +41,13 @@ class GetVersions
         }
 
         $installedTools = json_decode((string) file_get_contents($installedJson));
-        if (!is_array($installedTools)) {
+        if (!is_array($installedTools) && !is_object($installedTools)) {
             return [];
+        }
+
+        // Composer 2 has the tools under a key "packages"
+        if(is_object($installedTools)) {
+            $installedTools = $installedTools->packages;
         }
 
         $tools = array();


### PR DESCRIPTION
This PR allows to parse the `installed.json` generated by composer 2 as the format changed.
Due to this change it was not possible anymore to get the current versions of the installed tools.

https://getcomposer.org/upgrade/UPGRADE-2.0.md

> vendor/composer/installed.json format changed:
> * packages are now wrapped into a "packages" top level key instead of the whole file being the package array