### PR TITLE
fix: add 'packages' key check to Composer 2

### DIFF
--- a/src/Tools/GetVersions.php
+++ b/src/Tools/GetVersions.php
@@ -40,7 +40,11 @@ class GetVersions
             return [];
         }
 
-        $installedTools = json_decode((string) file_get_contents($installedJson));
+        $parsedInstalledJson = json_decode((string) file_get_contents($installedJson));
+
+        // Has a "packages" key in Composer 2
+        $installedTools = $parsedInstalledJson->packages ? $parsedInstalledJson->packages : $parsedInstalledJson;
+
         if (!is_array($installedTools)) {
             return [];
         }


### PR DESCRIPTION
In composer 2 has added a "packages" key. This PR checks for this key.