### PR TITLE
Replace abandoned Sensiolabs security checker

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,7 +34,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        extensions: xsl
+        extensions: xsl, zip, json
         coverage: none
         # TODO: ? https://github.com/EdgedesignCZ/phpqa/runs/1813676801?check_suite_focus=true#step:6:28 ?
         tools: composer:v1

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ you want to use them.
 
 Tool | PHP | Supported since | Description |
 ---- | --- | --------------- | ----------- |
-[security-checker](https://github.com/sensiolabs/security-checker) | `>= 5.3` | `1.16` | Check composer.lock for known security issues |
+[security-checker](https://github.com/enlightn/security-checker) | `>= 5.6` | `1.24` | Check composer.lock for known security issues |
 [php-cs-fixer](http://cs.sensiolabs.org/) | [`>= 5.3`](https://github.com/EdgedesignCZ/phpqa/pull/66#discussion_r115206573) | `1.12` | Automatically detect and fix PHP coding standards issues |
 [phpunit](https://github.com/phpunit/phpunit) | `>= 5.3` | `1.13` | The PHP Unit Testing framework |
 [phpstan](https://github.com/phpstan/phpstan) | `>= 7.0` | `1.9` | Discover bugs in your code without running it |

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -44,7 +44,7 @@ show_help() {
 }
 
 get_tools () {
-    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter sensiolabs/security-checker friendsofphp/php-cs-fixer:>=2"
+    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter enlightn/security-checker friendsofphp/php-cs-fixer:>=2"
     if [[ ${PHP_VERSION:0:1} != "5" ]]; then
         TOOLS="${TOOLS} vimeo/psalm:>=2 phpstan/phpstan nette/neon"
     fi

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -44,9 +44,13 @@ show_help() {
 }
 
 get_tools () {
-    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter enlightn/security-checker friendsofphp/php-cs-fixer:>=2"
+    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter friendsofphp/php-cs-fixer:>=2"
     if [[ ${PHP_VERSION:0:1} != "5" ]]; then
         TOOLS="${TOOLS} vimeo/psalm:>=2 phpstan/phpstan nette/neon"
+    fi
+    if [[ $UPDATE_COMPOSER == "yes" ]]; then
+        # security-checker does not support symfony2, so it cannot be installed on default composer.lock
+        TOOLS="${TOOLS} enlightn/security-checker"
     fi
     echo $TOOLS
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpmetrics/phpmetrics": "*"
     },
     "suggest": {
-        "sensiolabs/security-checker": "Check composer.lock for known security issues",
+        "enlightn/security-checker": "Check composer.lock for known security issues",
         "friendsofphp/php-cs-fixer": "A tool to automatically fix PHP coding standards issues",
         "phpunit/phpunit": "The PHP Unit Testing framework",
         "phpstan/phpstan": "PHP Static Analysis Tool - discover bugs in your code without running it!",

--- a/src/Tools/Analyzer/SecurityChecker.php
+++ b/src/Tools/Analyzer/SecurityChecker.php
@@ -8,9 +8,9 @@ class SecurityChecker extends \Edge\QA\Tools\Tool
 {
     public static $SETTINGS = array(
         'optionSeparator' => '=',
-        'internalClass' => 'SensioLabs\Security\SecurityChecker',
+        'internalClass' => 'Enlightn\SecurityChecker\AdvisoryAnalyzer',
         'outputMode' => OutputMode::RAW_CONSOLE_OUTPUT,
-        'composer' => 'sensiolabs/security-checker',
+        'composer' => 'enlightn/security-checker',
     );
 
     public function __invoke()

--- a/tests/.ci/.phpqa.yml
+++ b/tests/.ci/.phpqa.yml
@@ -21,7 +21,7 @@ phpqa:
         - phpstan
         - phpunit:0
         - psalm
-        - security-checker
+        - security-checker:0
         - parallel-lint:0
 
 phpcs:


### PR DESCRIPTION
This PR replaces the abandoned [Sensiolabs security checker](https://github.com/sensiolabs/security-checker) with the [Enlightn security checker](https://github.com/enlightn/security-checker). 