### PR TITLE
Tools - fix loading versions installed by composer 2.0, upgrade tools versions and config

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -74,28 +74,14 @@ jobs:
         echo
 
     - name: Show versions
-      env:
-        CI_PHP_VERSION: ${{ matrix.php }}
       run: |
         composer outdated --direct --all
-        if [[ ${CI_PHP_VERSION:0:3} == "8" ]]; then
-            # TODO: enable phpqa when robo v2 is supported
-            echo "Old robo causes fatal errors on php8..."
-        else
-            ./phpqa tools
-        fi
+        ./phpqa tools
 
     - name: Run tests
-      env:
-        CI_PHP_VERSION: ${{ matrix.php }}
       run: |
         vendor/phpunit/phpunit/phpunit
-        if [[ ${CI_PHP_VERSION:0:3} == "8" ]]; then
-            # TODO: enable phpqa when robo v2 is supported
-            mkdir -p build
-        else
-            bin/ci.sh
-        fi
+        bin/ci.sh
         ls -lAh build
 
     - name: Upload QA files

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -50,7 +50,7 @@ jobs:
             composer remove phpunit/phpunit --dev --no-interaction && composer remove sebastian/phpcpd --no-interaction;
             # 2) update tools
             composer update;
-            # 3) reinstall sebastian...
+            # 3) reinstall sebastian... (phpcpd v4)
             composer require phpunit/phpunit:~7.0 --dev && composer require sebastian/phpcpd;
             # 4) install suggested tools
             bin/suggested-tools.sh install;
@@ -60,8 +60,8 @@ jobs:
             composer remove phpunit/phpunit --dev --no-interaction && composer remove sebastian/phpcpd --no-interaction;
             # 2) update tools
             composer update;
-            # 3) reinstall latest versions TODO: phpcpd v6
-            composer require phpunit/phpunit --dev;
+            # 3) reinstall latest versions (phpcpd v6)
+            composer require phpunit/phpunit --dev && composer require sebastian/phpcpd;
             # 4) install suggested tools
             bin/suggested-tools.sh install;
             # 5) fix new php versions
@@ -90,10 +90,7 @@ jobs:
         CI_PHP_VERSION: ${{ matrix.php }}
       run: |
         vendor/phpunit/phpunit/phpunit
-        if [[ ${CI_PHP_VERSION:0:3} == "7.4" ]]; then
-            # TODO: revert when phpcpd v6 is supported
-            ./phpqa --config tests/.ci --tools "phpmetrics:0,phploc,phpcs:0,php-cs-fixer,phpmd:0,pdepend,phpcpd,phpstan,phpunit:0,psalm,security-checker,parallel-lint:0"
-        elif [[ ${CI_PHP_VERSION:0:3} == "8" ]]; then
+        if [[ ${CI_PHP_VERSION:0:3} == "8" ]]; then
             # TODO: enable phpqa when robo v2 is supported
             mkdir -p build
         else

--- a/.phpqa.yml
+++ b/.phpqa.yml
@@ -63,6 +63,8 @@ phpmetrics:
 
 phpstan:
     level: 0
+    # https://github.com/phpstan/phpstan/issues/1880
+    memoryLimit: null
     # https://github.com/phpstan/phpstan#configuration
     # standard: tests/.ci/phpstan.neon
 
@@ -82,6 +84,8 @@ psalm:
     deadCode: false
     threads: 1
     showInfo: true
+    # no memory limit = using ini defaults (https://github.com/EdgedesignCZ/phpqa/issues/144
+    memoryLimit: null
 
 # paths are relative to .phpqa.yml, so don't copy-paste this section if you don't have custom templates
 report:

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Tool | Settings | Default Value | Your value
 [pdepend.coverageReport](https://github.com/EdgedesignCZ/phpqa/pull/124) | Load Clover style CodeCoverage report | `null` | Path to report produced by PHPUnit's `--coverage-clover` option
 [phpmd.standard](http://phpmd.org/documentation/creating-a-ruleset.html) | Ruleset | [Edgedesign's standard](/app/phpmd.xml) | Path to ruleset. To specify [multiple rule sets](https://phpmd.org/documentation/index.html#using-multiple-rule-sets), you can use an array
 [phpcpd](https://github.com/sebastianbergmann/phpcpd/blob/de9056615da6c1230f3294384055fa7d722c38fa/src/CLI/Command.php#L136) | Minimum number of lines/tokens for copy-paste detection | 5 lines, 70 tokens |
-[phpstan](https://github.com/phpstan/phpstan#configuration) | Level, config file | Level 0, `%currentWorkingDirectory%/phpstan.neon` | Take a look at [phpqa config in tests/.ci](/tests/.ci/) |
+[phpstan](https://github.com/phpstan/phpstan#configuration) | Level, config file, memory limit | Level 0, `%currentWorkingDirectory%/phpstan.neon`, memoryLimit: null | Take a look at [phpqa config in tests/.ci](/tests/.ci/) |
 [phpunit.binary](https://github.com/EdgedesignCZ/phpqa/blob/4947416/.phpqa.yml#L40) | Phpunit binary  | phpqa's phpunit | Path to phpunit executable in your project, typically [`vendor/bin/phpunit`](https://gitlab.com/costlocker/integrations/blob/master/basecamp/backend/.phpqa.yml#L2) |
 [phpunit.config](https://phpunit.de/manual/current/en/organizing-tests.html#organizing-tests.xml-configuration) | PHPUnit configuration, `analyzedDirs` and `ignoredDirs` are not used, you have to specify test suites in XML file | `null` | Path to `phpunit.xml` file
 [phpunit.reports](https://phpunit.de/manual/current/en/textui.html) | Report types  | no report | List of reports and formats, corresponds with CLI option, e.g. `--log-junit` is `log: [junit]` in `.phpqa.yml` |
@@ -263,6 +263,7 @@ Tool | Settings | Default Value | Your value
 [psalm.deadCode](https://github.com/vimeo/psalm/wiki/Running-Psalm#command-line-options) | Enable or not `--find-dead-code` option  of psalm | `false` | Boolean value
 [psalm.threads](https://github.com/vimeo/psalm/wiki/Running-Psalm#command-line-options) | Set the number of process to use in parallel (option `--threads` of psalm) (Only if `--execution == parallel` for phpqa) | `1` | Number (>= 1)
 [psalm.showInfo](https://github.com/vimeo/psalm/wiki/Running-Psalm#command-line-options) | Display or not information (non-error) messages (option `--show-info=` of psalm) | `true` | Boolean value
+[psalm.memoryLimit](https://github.com/vimeo/psalm/issues/842) | Custom memory limit, ignore unless you are getting `Fatal error: Allowed memory size of ... bytes exhausted` | `null` | String value, e.g. `'1024M'`, `'1G'`
 
 `.phpqa.yml` is automatically detected in current working directory, but you can specify
 directory via option:

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -13,12 +13,12 @@ then
     echo "Installing suggested tools"
     if [ ! -z "$requireMode" ]; then
         # docker build OR travis + php 7.0 OR symfony2 (default composer.lock)
-        composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan:~0.12.0 nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm:~1 sensiolabs/security-checker:~5 $requireMode 
+        composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan:~0.12.0 nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm:~1 sensiolabs/security-checker:~5 $requireMode 
     else
         # symfony 3
-        composer require jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm sensiolabs/security-checker
+        composer require php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm sensiolabs/security-checker
     fi
 else
     echo "Removing suggested tools"
-    composer remove jakub-onderka/php-parallel-lint jakub-onderka/php-console-highlighter phpstan/phpstan friendsofphp/php-cs-fixer vimeo/psalm sensiolabs/security-checker
+    composer remove php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan friendsofphp/php-cs-fixer vimeo/psalm sensiolabs/security-checker
 fi

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -13,10 +13,10 @@ then
     echo "Installing suggested tools"
     if [ ! -z "$requireMode" ]; then
         # docker build OR travis + php 7.0 OR symfony2 (default composer.lock)
-        composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan:~0.12.0 nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm:~1 sensiolabs/security-checker:~5 $requireMode 
+        composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm:~2 sensiolabs/security-checker $requireMode 
     else
         # symfony 3
-        composer require php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm sensiolabs/security-checker
+        composer require php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan nette/neon friendsofphp/php-cs-fixer vimeo/psalm sensiolabs/security-checker
     fi
 else
     echo "Removing suggested tools"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.4",
         "ext-xsl": "*",
-        "consolidation/robo": "~0.5|~1",
+        "consolidation/robo": "~0.5|~1|~2",
         "phpmd/phpmd" : "*",
         "phploc/phploc": "*",
         "symfony/dependency-injection": ">=2.8.50",
@@ -27,7 +27,7 @@
         "symfony/process": ">=2.8",
         "symfony/finder": ">=2.8",
         "symfony/yaml": ">=2.8",
-        "twig/twig": "~1.38|~2.7",
+        "twig/twig": "~1.38|~2.7|~3",
         "pdepend/pdepend": "*",
         "sebastian/phpcpd": "*",
         "squizlabs/php_codesniffer": "*",

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
         "phpunit/phpunit": "The PHP Unit Testing framework",
         "phpstan/phpstan": "PHP Static Analysis Tool - discover bugs in your code without running it!",
         "vimeo/psalm": "A static analysis tool for finding errors in PHP applications",
-        "jakub-onderka/php-parallel-lint": "Check PHP syntax",
-        "jakub-onderka/php-console-highlighter": "Colored output in parallel-lint"
+        "php-parallel-lint/php-parallel-lint": "Check PHP syntax",
+        "php-parallel-lint/php-console-highlighter": "Colored output in parallel-lint"
     },
     "require-dev": {
         "hamcrest/hamcrest-php": ">=2.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a60c62c4d611b18bb75af69f32687fda",
+    "content-hash": "eba65bd26f6c18c7fac421784536ed0b",
     "packages": [
         {
             "name": "composer/xdebug-handler",

--- a/composer.lock
+++ b/composer.lock
@@ -7,6 +7,50 @@
     "content-hash": "a60c62c4d611b18bb75af69f32687fda",
     "packages": [
         {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "time": "2020-11-13T08:04:11+00:00"
+        },
+        {
             "name": "consolidation/robo",
             "version": "0.7.2",
             "source": {
@@ -727,32 +771,39 @@
         },
         {
             "name": "pdepend/pdepend",
-            "version": "2.5.2",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "9daf26d0368d4a12bed1cacae1a9f3a6f0adf239"
+                "reference": "c64472f8e76ca858c79ad9a4cf1e2734b3f8cc38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/9daf26d0368d4a12bed1cacae1a9f3a6f0adf239",
-                "reference": "9daf26d0368d4a12bed1cacae1a9f3a6f0adf239",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/c64472f8e76ca858c79ad9a4cf1e2734b3f8cc38",
+                "reference": "c64472f8e76ca858c79ad9a4cf1e2734b3f8cc38",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.7",
-                "symfony/config": "^2.3.0|^3|^4",
-                "symfony/dependency-injection": "^2.3.0|^3|^4",
-                "symfony/filesystem": "^2.3.0|^3|^4"
+                "symfony/config": "^2.3.0|^3|^4|^5",
+                "symfony/dependency-injection": "^2.3.0|^3|^4|^5",
+                "symfony/filesystem": "^2.3.0|^3|^4|^5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8|^5.7",
+                "easy-doc/easy-doc": "0.0.0 || ^1.2.3",
+                "gregwar/rst": "^1.0",
+                "phpunit/phpunit": "^4.8.35|^5.7",
                 "squizlabs/php_codesniffer": "^2.0.0"
             },
             "bin": [
                 "src/bin/pdepend"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PDepend\\": "src/main/php/PDepend"
@@ -763,7 +814,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2017-12-13T13:21:38+00:00"
+            "time": "2020-06-20T10:53:13+00:00"
         },
         {
             "name": "phploc/phploc",
@@ -820,24 +871,28 @@
         },
         {
             "name": "phpmd/phpmd",
-            "version": "2.7.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "a05a999c644f4bc9a204846017db7bb7809fbe4c"
+                "reference": "ce10831d4ddc2686c1348a98069771dd314534a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/a05a999c644f4bc9a204846017db7bb7809fbe4c",
-                "reference": "a05a999c644f4bc9a204846017db7bb7809fbe4c",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/ce10831d4ddc2686c1348a98069771dd314534a8",
+                "reference": "ce10831d4ddc2686c1348a98069771dd314534a8",
                 "shasum": ""
             },
             "require": {
+                "composer/xdebug-handler": "^1.0",
                 "ext-xml": "*",
-                "pdepend/pdepend": "^2.5",
+                "pdepend/pdepend": "^2.7.1",
                 "php": ">=5.3.9"
             },
             "require-dev": {
+                "easy-doc/easy-doc": "0.0.0 || ^1.3.2",
+                "ext-json": "*",
+                "ext-simplexml": "*",
                 "gregwar/rst": "^1.0",
                 "mikey179/vfsstream": "^1.6.4",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.27",
@@ -884,7 +939,7 @@
                 "phpmd",
                 "pmd"
             ],
-            "time": "2019-07-30T21:13:32+00:00"
+            "time": "2020-09-23T22:06:32+00:00"
         },
         {
             "name": "phpmetrics/phpmetrics",
@@ -998,6 +1053,53 @@
                 "timer"
             ],
             "time": "2017-02-26T11:10:40+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sebastian/finder-facade",

--- a/src/Tools/Analyzer/ParallelLint.php
+++ b/src/Tools/Analyzer/ParallelLint.php
@@ -10,7 +10,7 @@ class ParallelLint extends \Edge\QA\Tools\Tool
         'optionSeparator' => ' ',
         'internalClass' => 'JakubOnderka\PhpParallelLint\ParallelLint',
         'outputMode' => OutputMode::RAW_CONSOLE_OUTPUT,
-        'composer' => 'jakub-onderka/php-parallel-lint',
+        'composer' => 'php-parallel-lint/php-parallel-lint',
     );
 
     public function __invoke()

--- a/src/Tools/Analyzer/Phpcpd.php
+++ b/src/Tools/Analyzer/Phpcpd.php
@@ -21,7 +21,7 @@ class Phpcpd extends \Edge\QA\Tools\Tool
             'min-lines' => $this->config->value('phpcpd.minLines'),
             'min-tokens' => $this->config->value('phpcpd.minTokens'),
         );
-        $isOlderVersion = $this->isOlderVersionThanV6();
+        $isOlderVersion = $this->toolVersionIs('<', '6');
         $phpcpdNames = array_map(
             function ($extension) use ($isOlderVersion) {
                 return $isOlderVersion ? "*.{$extension}" : ".{$extension}";
@@ -39,12 +39,5 @@ class Phpcpd extends \Edge\QA\Tools\Tool
             $args['log-pmd'] = $this->tool->getEscapedXmlFile();
         }
         return $args;
-    }
-
-    private function isOlderVersionThanV6()
-    {
-        $versions = new GetVersions();
-        $composerVersion = $versions->getToolVersion(self::$SETTINGS);
-        return $composerVersion && version_compare($composerVersion, '6', '<');
     }
 }

--- a/src/Tools/Analyzer/Phpcpd.php
+++ b/src/Tools/Analyzer/Phpcpd.php
@@ -2,6 +2,8 @@
 
 namespace Edge\QA\Tools\Analyzer;
 
+use Edge\QA\Tools\GetVersions;
+
 class Phpcpd extends \Edge\QA\Tools\Tool
 {
     public static $SETTINGS = array(
@@ -14,24 +16,35 @@ class Phpcpd extends \Edge\QA\Tools\Tool
     public function __invoke()
     {
         $args = array(
-            'progress' => '',
             $this->options->ignore->bergmann(),
             $this->options->getAnalyzedDirs(' '),
             'min-lines' => $this->config->value('phpcpd.minLines'),
             'min-tokens' => $this->config->value('phpcpd.minTokens'),
         );
+        $isOlderVersion = $this->isOlderVersionThanV6();
         $phpcpdNames = array_map(
-            function ($extension) {
-                return "*.{$extension}";
+            function ($extension) use ($isOlderVersion) {
+                return $isOlderVersion ? "*.{$extension}" : ".{$extension}";
             },
             array_filter(explode(',', $this->config->csv('phpqa.extensions')))
         );
+        if ($isOlderVersion) {
+            $args['progress'] = '';
+        }
         if ($phpcpdNames) {
-            $args['names'] = \Edge\QA\escapePath(implode(',', $phpcpdNames));
+            $namesOptions = $isOlderVersion ? 'names' : 'suffix';
+            $args[$namesOptions] = \Edge\QA\escapePath(implode(',', $phpcpdNames));
         }
         if ($this->options->isSavedToFiles) {
             $args['log-pmd'] = $this->tool->getEscapedXmlFile();
         }
         return $args;
+    }
+
+    private function isOlderVersionThanV6()
+    {
+        $versions = new GetVersions();
+        $composerVersion = $versions->getToolVersion(self::$SETTINGS);
+        return $composerVersion && version_compare($composerVersion, '6', '<');
     }
 }

--- a/src/Tools/Analyzer/Phpstan.php
+++ b/src/Tools/Analyzer/Phpstan.php
@@ -65,8 +65,6 @@ class Phpstan extends \Edge\QA\Tools\Tool
 
     private function getErrorFormatOption()
     {
-        $versions = new GetVersions();
-        $phsptanVersion = $versions->getToolVersion(self::$SETTINGS);
-        return $phsptanVersion && version_compare($phsptanVersion, '0.10.3', '<') ?  'errorFormat' : 'error-format';
+        return $this->toolVersionIs('<', '0.10.3') ?  'errorFormat' : 'error-format';
     }
 }

--- a/src/Tools/Analyzer/Phpstan.php
+++ b/src/Tools/Analyzer/Phpstan.php
@@ -53,7 +53,7 @@ class Phpstan extends \Edge\QA\Tools\Tool
         $phpstanConfig = "# Configuration generated in phpqa\n" . \Nette\Neon\Neon::encode($config);
         $neonFile = $this->saveDynamicConfig($phpstanConfig, 'neon');
 
-        return array(
+        $args = array(
             'analyze',
             'ansi' => '',
             $this->getErrorFormatOption() => 'checkstyle',
@@ -61,6 +61,10 @@ class Phpstan extends \Edge\QA\Tools\Tool
             'configuration' => $neonFile,
             $this->options->getAnalyzedDirs(' '),
         );
+        if ($this->config->value('phpstan.memoryLimit')) {
+            $args['memory-limit'] = $this->config->value('phpstan.memoryLimit');
+        }
+        return $args;
     }
 
     private function getErrorFormatOption()

--- a/src/Tools/Analyzer/Psalm.php
+++ b/src/Tools/Analyzer/Psalm.php
@@ -47,6 +47,11 @@ class Psalm extends \Edge\QA\Tools\Tool
     {
         $xml = new SimpleXMLElement($rawXml);
 
+        $attributes = $xml->attributes();
+        if (!isset($attributes['resolveFromConfigFile']) && $this->toolVersionIs('>=', '4')) {
+            $xml->addAttribute('resolveFromConfigFile', 'false');
+        }
+
         if (!isset($xml->projectFiles)) {
             $xml->addChild('projectFiles');
         }

--- a/src/Tools/Analyzer/Psalm.php
+++ b/src/Tools/Analyzer/Psalm.php
@@ -28,7 +28,6 @@ class Psalm extends \Edge\QA\Tools\Tool
         $args = array(
             'config' => $psalmFile,
             'show-info' => $this->config->value('psalm.showInfo') ? 'true' : 'false',
-            'use-ini-defaults' => '',
         );
         if ($this->options->isSavedToFiles) {
             $args['report'] = $this->options->toFile('psalm.xml');
@@ -38,6 +37,11 @@ class Psalm extends \Edge\QA\Tools\Tool
         }
         if ($this->options->isParallel && ((int) $this->config->value('psalm.threads')) > 1) {
             $args['threads'] = $this->config->value('psalm.threads');
+        }
+        if (!$this->config->value('psalm.memoryLimit')) {
+            $args['use-ini-defaults'] = '';
+        } elseif ($this->toolVersionIs('>=', '3.14')) {
+            $args['memory-limit'] = $this->config->value('psalm.memoryLimit');
         }
 
         return $args;

--- a/src/Tools/GetVersions.php
+++ b/src/Tools/GetVersions.php
@@ -132,10 +132,19 @@ class GetVersions
 
     private function loadVersionFromConsoleCommand($command)
     {
-        $process = new Process($command);
+        $process = $this->createSymfonyProcess($command);
         $process->run();
         $firstLine = $this->getFirstLine($process->getOutput());
         return $this->extractVersion($firstLine);
+    }
+
+    private function createSymfonyProcess($command)
+    {
+        if (!method_exists('Symfony\Component\Process\Process', 'setCommandLine')) {
+            return new Process([$command]);
+        } else {
+            return new Process($command);
+        }
     }
 
     private function getFirstLine($string)

--- a/src/Tools/GetVersions.php
+++ b/src/Tools/GetVersions.php
@@ -40,7 +40,8 @@ class GetVersions
             return [];
         }
 
-        $installedTools = json_decode((string) file_get_contents($installedJson));
+        $rawTools = json_decode((string) file_get_contents($installedJson));
+        $installedTools = is_object($rawTools) ? $rawTools->packages : $rawTools;
         if (!is_array($installedTools)) {
             return [];
         }

--- a/src/Tools/Tool.php
+++ b/src/Tools/Tool.php
@@ -35,6 +35,13 @@ abstract class Tool
         return \Edge\QA\escapePath($file);
     }
 
+    protected function toolVersionIs($operator, $version)
+    {
+        $versions = new GetVersions();
+        $composerVersion = $versions->getToolVersion(static::$SETTINGS);
+        return $composerVersion && version_compare($composerVersion, $version, $operator);
+    }
+
     protected function writeln($text)
     {
         $this->presenter->__invoke($text);

--- a/src/report.php
+++ b/src/report.php
@@ -5,13 +5,16 @@ namespace Edge\QA;
 use DOMDocument;
 use XSLTProcessor;
 use Exception;
-use Twig_Loader_Filesystem;
-use Twig_Environment;
 
 function twigToHtml($template, array $params, $outputFile)
 {
-    $loader = new Twig_Loader_Filesystem(__DIR__ . '/../app/report');
-    $twig = new Twig_Environment($loader);
+    if (class_exists('Twig_Environment')) {
+        $loader = new \Twig_Loader_Filesystem(__DIR__ . '/../app/report');
+        $twig = new \Twig_Environment($loader);
+    } else {
+        $loader = new \Twig\Loader\FilesystemLoader(__DIR__ . '/../app/report');
+        $twig = new \Twig\Environment($loader);
+    }
     $html = $twig->render($template, $params);
     file_put_contents($outputFile, $html);
 }

--- a/tests/.ci/.phpqa.yml
+++ b/tests/.ci/.phpqa.yml
@@ -43,6 +43,7 @@ psalm:
 
 phpstan:
     level: 7
+    # memoryLimit: 1G
     # https://github.com/phpstan/phpstan#configuration
     standard: phpstan.neon
 

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -23,12 +23,14 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         assertThat($config->path('phpmetrics.config'), is(nullValue()));
         assertThat($config->path('phpmd.standard'), is(nonEmptyString()));
         assertThat($config->value('phpstan.level'), identicalTo(0));
+        assertThat($config->value('phpstan.memoryLimit'), is(nullValue()));
         assertThat($config->value('phpunit.config'), is(nullValue()));
         assertThat($config->value('phpunit.reports.file'), is(emptyArray()));
         assertThat($config->value('psalm.config'), is(nonEmptyString()));
         assertThat($config->value('psalm.deadCode'), identicalTo(false));
         assertThat($config->value('psalm.threads'), identicalTo(1));
         assertThat($config->value('psalm.showInfo'), identicalTo(true));
+        assertThat($config->value('psalm.memoryLimit'), is(nullValue()));
         assertThat($config->value('phpmetrics.config'), is(nullValue()));
         assertThat($config->value('phpmetrics.junit'), is(nullValue()));
         assertThat($config->value('phpmetrics.composer'), is(nullValue()));


### PR DESCRIPTION
* [x] fix composer 2.0 - https://github.com/EdgedesignCZ/phpqa/pull/212, https://github.com/EdgedesignCZ/phpqa/pull/213
* [x] parallel-lint package - https://github.com/EdgedesignCZ/phpqa/pull/207
* [x] `composer outdated -D`
* [x] phpcpd v6 https://github.com/EdgedesignCZ/phpqa/pull/209
* [x] compatibility - twig3: closes https://github.com/EdgedesignCZ/phpqa/issues/203, symfony5: closes https://github.com/EdgedesignCZ/phpqa/issues/205, robo2 https://github.com/EdgedesignCZ/phpqa/pull/208
* [x] ~~phpstan xml error - [`simplexml_load_file(): build//phpstan.xml:1: parser error : Start tag expected, '<' not found`](https://github.com/EdgedesignCZ/phpqa/pull/218/checks?check_run_id=1814879010#step:6:1025) - phpstan xml error + phpmetrics v1 = [`Hoa main file (Core.php) must be included once.`](https://github.com/EdgedesignCZ/phpqa/pull/218/checks?check_run_id=1814968901#step:6:158)~~
* [x] psalm v4 - [psalm 4.4.1, php 7.2 - psalm.xml not found, `Could not resolve config path to /home/runner/work/phpqa/phpqa/build//vendor`](https://github.com/EdgedesignCZ/phpqa/pull/218/checks?check_run_id=1814878987#step:6:830), [same error for php 7.4](https://github.com/EdgedesignCZ/phpqa/pull/218/checks?check_run_id=1814879057#step:6:49), [psalm 1, php 7.1 works](https://github.com/EdgedesignCZ/phpqa/pull/218/checks?check_run_id=1814879010#step:6:310) - change in version? related to https://github.com/EdgedesignCZ/phpqa/issues/206? No, [default resolveFromConfigFile changed in v4](https://github.com/vimeo/psalm/releases/tag/4.0.0)
* [x] memory limit for psalm and phpstan (https://github.com/EdgedesignCZ/phpqa/pull/202)
* [x] suggested tools version - [outdated restriction](https://github.com/EdgedesignCZ/phpqa/commit/6ef3519) for php-cs-fixer + php > 7.2, psalm v2 can be installed with symfony2 components
