### PR TITLE
Tools - refactoring testing different php versions and installing suggested tools

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php:
+          - 5.4 # default composer.lock + suggested-tools
+          - 5.5 # default composer.lock
+          - 5.6 # default composer.lock + suggested-tools TODO: test updated composer.lock
+          - 7.0 # default composer.lock
+          - 7.1 # updated composer.lock + suggested-tools
+          - 7.2 # default composer.lock + suggested-tools
+          - 7.3 # default composer.lock
+          - 7.4 # updated composer.lock + suggested-tools
+          - 8.0 # updated composer.lock + suggested-tools
         stability: [prefer-stable]
 
     steps:
@@ -40,27 +49,24 @@ jobs:
       env:
         CI_PHP_VERSION: ${{ matrix.php }}
       run: |
-        if [[ ${CI_PHP_VERSION:0:1} == "8" ]]; then
-            composer install --no-interaction --no-progress --ignore-platform-reqs
-        else
-            composer install --no-interaction --no-progress
-        fi
+        composer install --no-interaction --no-progress --ignore-platform-reqs;
         if [ ${CI_PHP_VERSION:0:3} == "7.1" ] || [ ${CI_PHP_VERSION:0:3} == "7.4" ] || [ ${CI_PHP_VERSION:0:1} == "8" ]; then
             composer update;
             bin/suggested-tools.sh install;
-            php tests/.phpunit/fix-typehints.php
+            php tests/.phpunit/fix-typehints.php;
         fi
         # test installing suggested tools like docker image
         if [[ ${CI_PHP_VERSION:0:3} == "7.2" ]]; then
-            bin/suggested-tools.sh install --prefer-dist;
+            bin/suggested-tools.sh install;
         fi
         if [[ ${CI_PHP_VERSION:0:3} == "5.6" ]]; then
-            PHP7=no bin/suggested-tools.sh install --prefer-dist;
+            # TODO: composer update -> psalm troubles
+            # https://github.com/EdgedesignCZ/phpqa/pull/220/checks?check_run_id=1830691807#step:5:162
+            PHP7=no bin/suggested-tools.sh install;
         fi
         if [[ ${CI_PHP_VERSION:0:3} == "5.4" ]]; then
-            PHP7=no SYMFONY2=yes bin/suggested-tools.sh install --prefer-dist;
+            PHP7=no SYMFONY2=yes bin/suggested-tools.sh install;
         fi
-        echo
 
     - name: Show versions
       run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -69,10 +69,13 @@ jobs:
         fi
         # test installing suggested tools like docker image
         if [[ ${CI_PHP_VERSION:0:3} == "7.2" ]]; then
-            PSALM_VERSION=":~2" bin/suggested-tools.sh install --prefer-dist;
+            bin/suggested-tools.sh install --prefer-dist;
         fi
-        if [ ${CI_PHP_VERSION:0:3} == "5.4" ] || [ ${CI_PHP_VERSION:0:3} == "5.6" ]; then
+        if [[ ${CI_PHP_VERSION:0:3} == "5.6" ]]; then
             PHP7=no bin/suggested-tools.sh install --prefer-dist;
+        fi
+        if [[ ${CI_PHP_VERSION:0:3} == "5.4" ]]; then
+            PHP7=no SYMFONY2=yes bin/suggested-tools.sh install --prefer-dist;
         fi
         echo
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -51,7 +51,7 @@ jobs:
             # 2) update tools
             composer update;
             # 3) reinstall sebastian... (phpcpd v4)
-            composer require phpunit/phpunit:~7.0 --dev && composer require sebastian/phpcpd;
+            composer require phpunit/phpunit --dev && composer require sebastian/phpcpd;
             # 4) install suggested tools
             bin/suggested-tools.sh install;
         fi
@@ -69,7 +69,10 @@ jobs:
         fi
         # test installing suggested tools like docker image
         if [[ ${CI_PHP_VERSION:0:3} == "7.2" ]]; then
-            bin/suggested-tools.sh install --prefer-dist;
+            PSALM_VERSION=":~2" bin/suggested-tools.sh install --prefer-dist;
+        fi
+        if [ ${CI_PHP_VERSION:0:3} == "5.4" ] || [ ${CI_PHP_VERSION:0:3} == "5.6" ]; then
+            PHP7=no bin/suggested-tools.sh install --prefer-dist;
         fi
         echo
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,16 +12,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php:
-          - 5.4 # default composer.lock + suggested-tools
-          - 5.5 # default composer.lock
-          - 5.6 # updated composer.lock + suggested-tools
-          - 7.0 # default composer.lock
-          - 7.1 # updated composer.lock + suggested-tools
-          - 7.2 # default composer.lock + suggested-tools
-          - 7.3 # default composer.lock
-          - 7.4 # updated composer.lock + suggested-tools
-          - 8.0 # updated composer.lock + suggested-tools
+        php: [5.5]
+        include:    
+          # PHP5
+          - { php: 5.4, areSuggestedToolsInstalled: yes, areSymfony2ComponentsUsed: yes }
+          - { php: 5.6, isComposerUpdated: yes, areSuggestedToolsInstalled: yes }
+          # PHP7
+          - { php: 7.0 }
+          - { php: 7.1, isComposerUpdated: yes, areSuggestedToolsInstalled: yes }
+          - { php: 7.2, areSuggestedToolsInstalled: yes }
+          - { php: 7.3 }
+          - { php: 7.4, isComposerUpdated: yes, areSuggestedToolsInstalled: yes }
+          # PHP8
+          - { php: 8.0, isComposerUpdated: yes, areSuggestedToolsInstalled: yes }
         stability: [prefer-stable]
 
     steps:
@@ -47,25 +50,16 @@ jobs:
 
     - name: Install dependencies
       env:
-        CI_PHP_VERSION: ${{ matrix.php }}
+        PHP_VERSION: ${{ matrix.php }}
+        USE_SYMFONY2_COMPONENTS: ${{ matrix.areSymfony2ComponentsUsed || 'no' }}
+        UPDATE_COMPOSER: ${{ matrix.isComposerUpdated || 'no' }}
+        INSTALL_SUGGESTED_TOOLS: ${{ matrix.areSuggestedToolsInstalled || 'no' }}
       run: |
         composer install --no-interaction --no-progress --ignore-platform-reqs;
-        if [ ${CI_PHP_VERSION:0:3} == "7.1" ] || [ ${CI_PHP_VERSION:0:3} == "7.4" ] || [ ${CI_PHP_VERSION:0:1} == "8" ]; then
-            composer update;
-            bin/suggested-tools.sh install;
-            php tests/.phpunit/fix-typehints.php;
+        if [[ $INSTALL_SUGGESTED_TOOLS == "yes" ]]; then
+            PHP_VERSION=$PHP_VERSION USE_SYMFONY2_COMPONENTS=$USE_SYMFONY2_COMPONENTS UPDATE_COMPOSER=$UPDATE_COMPOSER bin/suggested-tools.sh install;
         fi
-        # test installing suggested tools like docker image
-        if [[ ${CI_PHP_VERSION:0:3} == "7.2" ]]; then
-            bin/suggested-tools.sh install;
-        fi
-        if [[ ${CI_PHP_VERSION:0:3} == "5.6" ]]; then
-            composer update
-            PHP7=no bin/suggested-tools.sh install;
-        fi
-        if [[ ${CI_PHP_VERSION:0:3} == "5.4" ]]; then
-            PHP7=no SYMFONY2=yes bin/suggested-tools.sh install;
-        fi
+        php tests/.phpunit/fix-typehints.php;
 
     - name: Show versions
       run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -45,26 +45,9 @@ jobs:
         else
             composer install --no-interaction --no-progress
         fi
-        if [[ ${CI_PHP_VERSION:0:3} == "7.1" ]]; then
-            # 1) delete sebastian dependency hell
-            composer remove phpunit/phpunit --dev --no-interaction && composer remove sebastian/phpcpd --no-interaction;
-            # 2) update tools
+        if [ ${CI_PHP_VERSION:0:3} == "7.1" ] || [ ${CI_PHP_VERSION:0:3} == "7.4" ] || [ ${CI_PHP_VERSION:0:1} == "8" ]; then
             composer update;
-            # 3) reinstall sebastian... (phpcpd v4)
-            composer require phpunit/phpunit --dev && composer require sebastian/phpcpd;
-            # 4) install suggested tools
             bin/suggested-tools.sh install;
-        fi
-        if [ ${CI_PHP_VERSION:0:3} == "7.4" ] || [ ${CI_PHP_VERSION:0:1} == "8" ]; then
-            # 1) delete sebastian dependency hell
-            composer remove phpunit/phpunit --dev --no-interaction && composer remove sebastian/phpcpd --no-interaction;
-            # 2) update tools
-            composer update;
-            # 3) reinstall latest versions (phpcpd v6)
-            composer require phpunit/phpunit --dev && composer require sebastian/phpcpd;
-            # 4) install suggested tools
-            bin/suggested-tools.sh install;
-            # 5) fix new php versions
             php tests/.phpunit/fix-typehints.php
         fi
         # test installing suggested tools like docker image

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
         php: [5.5]
         include:    
           # PHP5
-          - { php: 5.4, areSuggestedToolsInstalled: yes, areSymfony2ComponentsUsed: yes }
+          - { php: 5.4, areSuggestedToolsInstalled: yes }
           - { php: 5.6, isComposerUpdated: yes, areSuggestedToolsInstalled: yes }
           # PHP7
           - { php: 7.0 }
@@ -51,13 +51,12 @@ jobs:
     - name: Install dependencies
       env:
         PHP_VERSION: ${{ matrix.php }}
-        USE_SYMFONY2_COMPONENTS: ${{ matrix.areSymfony2ComponentsUsed || 'no' }}
         UPDATE_COMPOSER: ${{ matrix.isComposerUpdated || 'no' }}
         INSTALL_SUGGESTED_TOOLS: ${{ matrix.areSuggestedToolsInstalled || 'no' }}
       run: |
         composer install --no-interaction --no-progress --ignore-platform-reqs;
         if [[ $INSTALL_SUGGESTED_TOOLS == "yes" ]]; then
-            PHP_VERSION=$PHP_VERSION USE_SYMFONY2_COMPONENTS=$USE_SYMFONY2_COMPONENTS UPDATE_COMPOSER=$UPDATE_COMPOSER bin/suggested-tools.sh install;
+            PHP_VERSION=$PHP_VERSION UPDATE_COMPOSER=$UPDATE_COMPOSER bin/suggested-tools.sh install;
         fi
         php tests/.phpunit/fix-typehints.php;
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
         php:
           - 5.4 # default composer.lock + suggested-tools
           - 5.5 # default composer.lock
-          - 5.6 # default composer.lock + suggested-tools TODO: test updated composer.lock
+          - 5.6 # updated composer.lock + suggested-tools
           - 7.0 # default composer.lock
           - 7.1 # updated composer.lock + suggested-tools
           - 7.2 # default composer.lock + suggested-tools
@@ -60,8 +60,7 @@ jobs:
             bin/suggested-tools.sh install;
         fi
         if [[ ${CI_PHP_VERSION:0:3} == "5.6" ]]; then
-            # TODO: composer update -> psalm troubles
-            # https://github.com/EdgedesignCZ/phpqa/pull/220/checks?check_run_id=1830691807#step:5:162
+            composer update
             PHP7=no bin/suggested-tools.sh install;
         fi
         if [[ ${CI_PHP_VERSION:0:3} == "5.4" ]]; then

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -9,25 +9,25 @@ mode="$1"
 requireMode="$2"
 
 PHP7=${PHP7:-"yes"}
-PSALM_VERSION=${PSALM_VERSION:-""}
+SYMFONY2=${SYMFONY2:-"no"}
 
 if [ $mode = "install" ]
 then
     echo "Installing suggested tools"
-    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter sensiolabs/security-checker vimeo/psalm$PSALM_VERSION"
+    # psalm 0.2 for php 5.4, v2 can be minimum when php5.4 and symfony2 components are dropped
+    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter sensiolabs/security-checker vimeo/psalm:>=0.2 friendsofphp/php-cs-fixer:>=2"
     if [[ ${PHP7} == "yes" ]]; then
         TOOLS="${TOOLS} phpstan/phpstan nette/neon"
     fi
-    echo $TOOLS
-    echo
-
-    if [ ! -z "$requireMode" ]; then
-        # docker build OR travis + php 7.0 OR symfony2 (default composer.lock)
-        composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 $TOOLS friendsofphp/php-cs-fixer:~2.2 $requireMode 
-    else
-        # symfony 3
-        composer require $TOOLS friendsofphp/php-cs-fixer
+    if [[ ${SYMFONY2} == "yes" ]]; then
+        # https://github.com/EdgedesignCZ/phpqa/commit/94e9b49
+        # https://github.com/EdgedesignCZ/phpqa/commit/13a8025
+        TOOLS="${TOOLS} symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2"
     fi
+    echo
+    echo "composer require $TOOLS $requireMode"
+    echo
+    composer require $TOOLS $requireMode
 else
     echo "Removing suggested tools"
     composer remove php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan friendsofphp/php-cs-fixer vimeo/psalm sensiolabs/security-checker

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -1,39 +1,75 @@
 #!/bin/bash
 
-# Usage:
+# PHP_VERSION=number UPDATE_COMPOSER=yes|no bin/suggested-tools.sh <install|remove> <composer_require_modes>
+#
+# Help:
+#  $ bin/suggested-tools.sh
 #  $ bin/suggested-tools.sh install
 #  $ bin/suggested-tools.sh install --update-no-dev
 #  $ bin/suggested-tools.sh remove
+#
+# Update existings tools before installing suggested tools:
+#  $ UPDATE_COMPOSER="yes" bin/suggested-tools.sh
+#
+# Usage for PHP5:
+#  $ PHP_VERSION="5" bin/suggested-tools.sh
 
-MODE="$1"
+COMMAND="$0"
+SELECTED_MODE="$1"
 COMPOSER_REQUIRE_MODES="$2"
 
 PHP_VERSION=${PHP_VERSION:-"7"}
 UPDATE_COMPOSER=${UPDATE_COMPOSER:-"no"}
-IS_NOT_PHP5="yes"
-if [[ ${PHP_VERSION:0:1} == "5" ]]; then
-    IS_NOT_PHP5="no"
-fi
 
-echo "$ PHP_VERSION=$PHP_VERSION UPDATE_COMPOSER=$UPDATE_COMPOSER bin/suggested-tools.sh $MODE"
-echo
+run () {
+    TOOLS=$(get_tools)
+    if [ -z "$SELECTED_MODE" ]; then
+        show_help "install"
+        show_help "remove"
+        echo "Available tools: $TOOLS"
+        exit 1
+    fi
+    show_help $SELECTED_MODE
+    if [[ $SELECTED_MODE = "install" ]]; then
+        install "$TOOLS"
+    else
+        remove "$TOOLS"
+    fi
+}
 
-if [ $MODE = "install" ]
-then
+show_help() {
+    MODE=$1
+    echo "$ PHP_VERSION=$PHP_VERSION UPDATE_COMPOSER=$UPDATE_COMPOSER $COMMAND $MODE $COMPOSER_REQUIRE_MODES"
+    echo
+}
+
+get_tools () {
+    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter sensiolabs/security-checker friendsofphp/php-cs-fixer:>=2"
+    if [[ ${PHP_VERSION:0:1} != "5" ]]; then
+        TOOLS="${TOOLS} vimeo/psalm:>=2 phpstan/phpstan nette/neon"
+    fi
+    echo $TOOLS
+}
+
+install () {
+    TOOLS=$1
     if [[ $UPDATE_COMPOSER == "yes" ]]; then
         echo "> Updating installed tools"
         echo
         composer update
     fi
     echo "> Installing suggested tools"
-    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter sensiolabs/security-checker friendsofphp/php-cs-fixer:>=2"
-    if [[ $IS_NOT_PHP5 == "yes" ]]; then
-        TOOLS="${TOOLS} vimeo/psalm:>=2 phpstan/phpstan nette/neon"
-    fi
     echo "$ composer require $TOOLS $COMPOSER_REQUIRE_MODES"
     echo
     composer require $TOOLS $COMPOSER_REQUIRE_MODES
-else
+}
+
+remove () {
+    TOOLS=${1/:>=2/""}
     echo "> Removing suggested tools"
-    composer remove php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan friendsofphp/php-cs-fixer vimeo/psalm sensiolabs/security-checker
-fi
+    echo "$ composer require $TOOLS $COMPOSER_REQUIRE_MODES"
+    echo
+    composer remove $TOOLS
+}
+
+run

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -8,15 +8,25 @@
 mode="$1"
 requireMode="$2"
 
+PHP7=${PHP7:-"yes"}
+PSALM_VERSION=${PSALM_VERSION:-""}
+
 if [ $mode = "install" ]
 then
     echo "Installing suggested tools"
+    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter sensiolabs/security-checker vimeo/psalm$PSALM_VERSION"
+    if [[ ${PHP7} == "yes" ]]; then
+        TOOLS="${TOOLS} phpstan/phpstan nette/neon"
+    fi
+    echo $TOOLS
+    echo
+
     if [ ! -z "$requireMode" ]; then
         # docker build OR travis + php 7.0 OR symfony2 (default composer.lock)
-        composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan nette/neon friendsofphp/php-cs-fixer:~2.2 vimeo/psalm:~2 sensiolabs/security-checker $requireMode 
+        composer require symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2 $TOOLS friendsofphp/php-cs-fixer:~2.2 $requireMode 
     else
         # symfony 3
-        composer require php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan nette/neon friendsofphp/php-cs-fixer vimeo/psalm sensiolabs/security-checker
+        composer require $TOOLS friendsofphp/php-cs-fixer
     fi
 else
     echo "Removing suggested tools"

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -14,10 +14,9 @@ SYMFONY2=${SYMFONY2:-"no"}
 if [ $mode = "install" ]
 then
     echo "Installing suggested tools"
-    # psalm 0.2 for php 5.4, v2 can be minimum when php5.4 and symfony2 components are dropped
-    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter sensiolabs/security-checker vimeo/psalm:>=0.2 friendsofphp/php-cs-fixer:>=2"
+    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter sensiolabs/security-checker friendsofphp/php-cs-fixer:>=2"
     if [[ ${PHP7} == "yes" ]]; then
-        TOOLS="${TOOLS} phpstan/phpstan nette/neon"
+        TOOLS="${TOOLS} vimeo/psalm:>=2 phpstan/phpstan nette/neon"
     fi
     if [[ ${SYMFONY2} == "yes" ]]; then
         # https://github.com/EdgedesignCZ/phpqa/commit/94e9b49

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Usage:
 #  $ bin/suggested-tools.sh install
@@ -6,7 +6,7 @@
 #  $ bin/suggested-tools.sh remove
 
 mode="$1"
-requireMode="$2"
+COMPOSER_REQUIRE_MODES="$2"
 
 PHP7=${PHP7:-"yes"}
 SYMFONY2=${SYMFONY2:-"no"}
@@ -25,9 +25,9 @@ then
         TOOLS="${TOOLS} symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2"
     fi
     echo
-    echo "composer require $TOOLS $requireMode"
+    echo "composer require $TOOLS $COMPOSER_REQUIRE_MODES"
     echo
-    composer require $TOOLS $requireMode
+    composer require $TOOLS $COMPOSER_REQUIRE_MODES
 else
     echo "Removing suggested tools"
     composer remove php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan friendsofphp/php-cs-fixer vimeo/psalm sensiolabs/security-checker

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -9,14 +9,13 @@ MODE="$1"
 COMPOSER_REQUIRE_MODES="$2"
 
 PHP_VERSION=${PHP_VERSION:-"7"}
-USE_SYMFONY2_COMPONENTS=${USE_SYMFONY2_COMPONENTS:-"no"}
 UPDATE_COMPOSER=${UPDATE_COMPOSER:-"no"}
 IS_NOT_PHP5="yes"
 if [[ ${PHP_VERSION:0:1} == "5" ]]; then
     IS_NOT_PHP5="no"
 fi
 
-echo "$ PHP_VERSION=$PHP_VERSION USE_SYMFONY2_COMPONENTS=$USE_SYMFONY2_COMPONENTS UPDATE_COMPOSER=$UPDATE_COMPOSER bin/suggested-tools.sh $MODE"
+echo "$ PHP_VERSION=$PHP_VERSION UPDATE_COMPOSER=$UPDATE_COMPOSER bin/suggested-tools.sh $MODE"
 echo
 
 if [ $MODE = "install" ]
@@ -30,11 +29,6 @@ then
     TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter sensiolabs/security-checker friendsofphp/php-cs-fixer:>=2"
     if [[ $IS_NOT_PHP5 == "yes" ]]; then
         TOOLS="${TOOLS} vimeo/psalm:>=2 phpstan/phpstan nette/neon"
-    fi
-    if [[ $USE_SYMFONY2_COMPONENTS == "yes" ]]; then
-        # https://github.com/EdgedesignCZ/phpqa/commit/94e9b49
-        # https://github.com/EdgedesignCZ/phpqa/commit/13a8025
-        TOOLS="${TOOLS} symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2"
     fi
     echo "$ composer require $TOOLS $COMPOSER_REQUIRE_MODES"
     echo

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -5,29 +5,41 @@
 #  $ bin/suggested-tools.sh install --update-no-dev
 #  $ bin/suggested-tools.sh remove
 
-mode="$1"
+MODE="$1"
 COMPOSER_REQUIRE_MODES="$2"
 
-PHP7=${PHP7:-"yes"}
-SYMFONY2=${SYMFONY2:-"no"}
+PHP_VERSION=${PHP_VERSION:-"7"}
+USE_SYMFONY2_COMPONENTS=${USE_SYMFONY2_COMPONENTS:-"no"}
+UPDATE_COMPOSER=${UPDATE_COMPOSER:-"no"}
+IS_NOT_PHP5="yes"
+if [[ ${PHP_VERSION:0:1} == "5" ]]; then
+    IS_NOT_PHP5="no"
+fi
 
-if [ $mode = "install" ]
+echo "$ PHP_VERSION=$PHP_VERSION USE_SYMFONY2_COMPONENTS=$USE_SYMFONY2_COMPONENTS UPDATE_COMPOSER=$UPDATE_COMPOSER bin/suggested-tools.sh $MODE"
+echo
+
+if [ $MODE = "install" ]
 then
-    echo "Installing suggested tools"
+    if [[ $UPDATE_COMPOSER == "yes" ]]; then
+        echo "> Updating installed tools"
+        echo
+        composer update
+    fi
+    echo "> Installing suggested tools"
     TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter sensiolabs/security-checker friendsofphp/php-cs-fixer:>=2"
-    if [[ ${PHP7} == "yes" ]]; then
+    if [[ $IS_NOT_PHP5 == "yes" ]]; then
         TOOLS="${TOOLS} vimeo/psalm:>=2 phpstan/phpstan nette/neon"
     fi
-    if [[ ${SYMFONY2} == "yes" ]]; then
+    if [[ $USE_SYMFONY2_COMPONENTS == "yes" ]]; then
         # https://github.com/EdgedesignCZ/phpqa/commit/94e9b49
         # https://github.com/EdgedesignCZ/phpqa/commit/13a8025
         TOOLS="${TOOLS} symfony/filesystem:~2 symfony/process:~2 symfony/finder:~2"
     fi
-    echo
-    echo "composer require $TOOLS $COMPOSER_REQUIRE_MODES"
+    echo "$ composer require $TOOLS $COMPOSER_REQUIRE_MODES"
     echo
     composer require $TOOLS $COMPOSER_REQUIRE_MODES
 else
-    echo "Removing suggested tools"
+    echo "> Removing suggested tools"
     composer remove php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter phpstan/phpstan friendsofphp/php-cs-fixer vimeo/psalm sensiolabs/security-checker
 fi

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "hamcrest/hamcrest-php": ">=2.0.1",
-        "phpunit/phpunit": "~4.8.28"
+        "phpunit/phpunit": ">=4.8.28"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eba65bd26f6c18c7fac421784536ed0b",
+    "content-hash": "ec09240db4a0684449ba9ea5f5e9733d",
     "packages": [
         {
             "name": "composer/xdebug-handler",

--- a/tests/.phpunit/fix-typehints.php
+++ b/tests/.phpunit/fix-typehints.php
@@ -1,5 +1,9 @@
 <?php
 
+if (version_compare(PHP_VERSION, '7.1.0', '<')) {
+    return;
+}
+
 $files = [
     'OptionsTest.php',
     'Report/ReportTest.php',


### PR DESCRIPTION
Related to changes in https://github.com/EdgedesignCZ/phpqa/pull/218. New [security-checker](https://github.com/EdgedesignCZ/phpqa/pull/215#issuecomment-770873236) and [psalm/php-cs-fixer](https://github.com/EdgedesignCZ/phpqa/commit/13a8025) needs at least Symfony3. [Symfony2](https://github.com/symfony/console/blob/3.4/composer.json#L19) is required only for PHP 5.4 _([5.4](https://github.com/EdgedesignCZ/phpqa/pull/215/checks?check_run_id=1829543696#step:6:14) vs [5.5](https://github.com/EdgedesignCZ/phpqa/pull/215/checks?check_run_id=1829543721#step:6:15))_.

* [x] refactoring suggested-tools.sh and php.yml
* [x] use default composer.lock and symfony2 suggested tools only for php 5.4