### PR TITLE
CI - use Ubuntu 20.04 and composer v2, fix detecting phpunit version

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   phpqa:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -36,8 +36,9 @@ jobs:
         php-version: ${{ matrix.php }}
         extensions: xsl, zip, json
         coverage: none
-        # TODO: ? https://github.com/EdgedesignCZ/phpqa/runs/1813676801?check_suite_focus=true#step:6:28 ?
-        tools: composer:v1
+        # default composer.lock with symfony2 components + psalm = composer error
+        # https://github.com/EdgedesignCZ/phpqa/runs/1844081585?check_suite_focus=true#step:5:112
+        tools: ${{ (matrix.php != '7.2' && 'composer:v2') || 'composer:v1' }}
 
     - name: Cache composer
       uses: actions/cache@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Show versions
       run: |
         composer outdated --direct --all
-        ./phpqa tools
+        ./phpqa tools --config tests/.ci 
 
     - name: Run tests
       run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ install:
 
 test_script:
     - cd C:\projects\phpqa
-    - php phpqa tools
+    - php phpqa tools --config tests/.appveyor
     - php phpqa --verbose --report --config tests/.appveyor
     - dir build
 

--- a/src/Tools/GetVersions.php
+++ b/src/Tools/GetVersions.php
@@ -140,8 +140,8 @@ class GetVersions
 
     private function createSymfonyProcess($command)
     {
-        if (!method_exists('Symfony\Component\Process\Process', 'setCommandLine')) {
-            return new Process([$command]);
+        if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandline')) {
+            return Process::fromShellCommandline($command);
         } else {
             return new Process($command);
         }


### PR DESCRIPTION
* [x] warning: Ubuntu-latest workflows will use Ubuntu-20.04 soon
* [x] composer2? [You are using Composer 2, which some of your plugins seem to be incompatible with.](https://github.com/EdgedesignCZ/phpqa/runs/1813676801?check_suite_focus=true#step:6:28)
* [x] invalid phpunit version from custom binary - `phpunit 9.5.2`, `php 7.4`