### PR TITLE
CI - hotfix building docker images after release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,15 @@
 name: PHPQA Docker
 
+# `push tag && master branch` is complicated... (checkout + fetch-depth:0 + find git branch from detached state)
+# https://dh1tw.de/2019/12/real-life-ci/cd-pipelines-with-github-actions/#insufficient-filtering
+# Release build is not visible from commit, but it's better than manually building docker images
+# https://stackoverflow.com/a/59894223, https://stackoverflow.com/a/57983436
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [created]
 
 jobs:
   phpqa:
-    if: github.event.base_ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
Partially reverts https://github.com/EdgedesignCZ/phpqa/commit/9bab2fd
https://github.community/t/run-workflow-on-push-tag-on-specific-branch/17519
https://github.com/EdgedesignCZ/phpqa/runs/1853774679?check_suite_focus=true
This check was skipped (because base_ref is null for master branch, it's filled only for PRs)

Current hotfix should not skip building docker images, but action won't be linked from commit.
Pushing tags to specific branch is complicated, so release hotfix is good enough at the moment.