### PR TITLE
Tools - refine support for custom binaries and tools installed with phar

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Tool | Settings | Default Value | Your value
 [psalm.showInfo](https://github.com/vimeo/psalm/wiki/Running-Psalm#command-line-options) | Display or not information (non-error) messages (option `--show-info=` of psalm) | `true` | Boolean value
 [psalm.memoryLimit](https://github.com/vimeo/psalm/issues/842) | Custom memory limit, ignore unless you are getting `Fatal error: Allowed memory size of ... bytes exhausted` | `null` | String value, e.g. `'1024M'`, `'1G'`
 
+### Files
+
 `.phpqa.yml` is automatically detected in current working directory, but you can specify
 directory via option:
 
@@ -305,6 +307,36 @@ Also, path inside configuration file are relative to where the configuration fil
 so if you have a package that bundle a custom tool, the `.phpqa.yml` in the package can refers files within it.
 ```bash
 phpqa --config ~/phpqa/,my-config/,$(pwd)
+```
+
+### Custom binary
+
+Every tool can define custom binary. Use phar or global tool, if you have troubles with dependencies, e.g.:
+
+* can't install something because of symfony components or php version
+* phpstan does not work, if phpmetrics v1 is installed in composer _(`Hoa main file (Core.php) must be included once.`)_ -> use phar for phpmetrics
+
+Generally, composer installation is preferred because of detecting version.
+Phar works too, but it might be tricky. If a tool has composer package with phar
+_(e.g. [vimeo/phar](https://packagist.org/packages/psalm/phar))_, use it instead of custom binary:
+
+```yaml
+psalm:
+    binary: /usr/local/bin/psalm.phar
+```
+
+Possibilities are infinite. You can [define new tool](https://github.com/EdgedesignCZ/phpqa/blob/master/.phpqa.yml#L120)
+and run it. For example I like `exploring codebase` in phpmetrics v1 and composer info in v2.
+Install phpmetrics v2 in composer and use phar for v1 to avoid phpstan conflicts:
+
+```bash
+$ cat tests/.ci/.phpqa.yml
+phpmetricsV1:
+    binary: /usr/local/bin/phpmetrics.phar
+tool:
+    phpmetricsV1: Edge\QA\Tools\Analyzer\PhpMetrics
+
+$ phpqa --config tests/.ci/ --tools phpmetricsV1,phpmetrics
 ```
 
 ## HTML reports
@@ -478,6 +510,6 @@ Contributions from others would be very much appreciated! Send
 
 ## License
 
-Copyright (c) 2015, 2016, 2017, 2018 Edgedesign.cz. MIT Licensed,
+Copyright (c) 2015 - present Edgedesign.cz. MIT Licensed,
 see [LICENSE](/LICENSE) for details.
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -54,15 +54,11 @@ class Config
 
     public function getCustomBinary($tool)
     {
-        $binary = $this->path("{$tool}.binary");
-        if ($binary) {
-            $filename = basename($binary);
-            if (is_bool(strpos($filename, "{$tool}"))) {
-                throw new \RuntimeException("Invalid '{$tool}' binary ('{$tool}' not found in '{$binary}')");
-            }
-            return $binary;
+        try {
+            return $this->path("{$tool}.binary");
+        } catch (\RuntimeException $e) {
+            return null;
         }
-        return null;
     }
 
     public function value($path)

--- a/src/Config.php
+++ b/src/Config.php
@@ -60,7 +60,7 @@ class Config
             if (is_bool(strpos($filename, "{$tool}"))) {
                 throw new \RuntimeException("Invalid '{$tool}' binary ('{$tool}' not found in '{$binary}')");
             }
-            return escapePath($binary);
+            return $binary;
         }
         return null;
     }

--- a/src/Options.php
+++ b/src/Options.php
@@ -90,7 +90,8 @@ class Options
                     'xml' => array_key_exists('xml', $config) ? array_map([$this, 'rawFile'], $config['xml']) : []
                 ];
                 $runningTool = new RunningTool($tool, $preload + $config);
-                $runningTool->isExecutable = $runningTool->isInstalled() || isset($config['customBinary']);
+                $runningTool->isExecutable =
+                    $config['runBinary'] && ($config['hasCustomBinary'] || $runningTool->isInstalled());
                 $allowed[$tool] = $runningTool;
             }
         }

--- a/src/Tools/Analyzer/ParallelLint.php
+++ b/src/Tools/Analyzer/ParallelLint.php
@@ -8,7 +8,6 @@ class ParallelLint extends \Edge\QA\Tools\Tool
 {
     public static $SETTINGS = array(
         'optionSeparator' => ' ',
-        'internalClass' => 'JakubOnderka\PhpParallelLint\ParallelLint',
         'outputMode' => OutputMode::RAW_CONSOLE_OUTPUT,
         'composer' => 'php-parallel-lint/php-parallel-lint',
     );

--- a/src/Tools/Analyzer/PhpCsFixer.php
+++ b/src/Tools/Analyzer/PhpCsFixer.php
@@ -8,7 +8,6 @@ class PhpCsFixer extends \Edge\QA\Tools\Tool
 {
     public static $SETTINGS = array(
         'optionSeparator' => ' ',
-        'internalClass' => 'PhpCsFixer\Config',
         'outputMode' => OutputMode::XML_CONSOLE_OUTPUT,
         'composer' => 'friendsofphp/php-cs-fixer',
         'xml' => ['php-cs-fixer.xml'],

--- a/src/Tools/Analyzer/Phpstan.php
+++ b/src/Tools/Analyzer/Phpstan.php
@@ -8,7 +8,6 @@ class Phpstan extends \Edge\QA\Tools\Tool
 {
     public static $SETTINGS = array(
         'optionSeparator' => ' ',
-        'internalClass' => 'PHPStan\Analyser\Analyser',
         'outputMode' => OutputMode::XML_CONSOLE_OUTPUT,
         'xml' => ['phpstan.xml'],
         'errorsXPath' => '//checkstyle/file/error',

--- a/src/Tools/Analyzer/Phpunit.php
+++ b/src/Tools/Analyzer/Phpunit.php
@@ -8,7 +8,6 @@ class Phpunit extends \Edge\QA\Tools\Tool
 {
     public static $SETTINGS = array(
         'optionSeparator' => '=',
-        'internalClass' => ['PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase'],
         'outputMode' => OutputMode::RAW_CONSOLE_OUTPUT,
         'composer' => 'phpunit/phpunit',
     );

--- a/src/Tools/Analyzer/Psalm.php
+++ b/src/Tools/Analyzer/Psalm.php
@@ -12,7 +12,6 @@ class Psalm extends \Edge\QA\Tools\Tool
         'xml' => ['psalm.xml'],
         'errorsXPath' => '//item/severity[text()=\'error\']',
         'composer' => 'vimeo/psalm',
-        'internalClass' => 'Psalm\CodeLocation',
     );
 
     public function __invoke()

--- a/src/Tools/Analyzer/SecurityChecker.php
+++ b/src/Tools/Analyzer/SecurityChecker.php
@@ -8,7 +8,6 @@ class SecurityChecker extends \Edge\QA\Tools\Tool
 {
     public static $SETTINGS = array(
         'optionSeparator' => '=',
-        'internalClass' => 'Enlightn\SecurityChecker\AdvisoryAnalyzer',
         'outputMode' => OutputMode::RAW_CONSOLE_OUTPUT,
         'composer' => 'enlightn/security-checker',
     );

--- a/src/Tools/GetVersions.php
+++ b/src/Tools/GetVersions.php
@@ -67,7 +67,6 @@ class GetVersions
         ));
 
         if ($binaries['hasCustomBinary']) {
-            $binary = \Edge\QA\escapePath($binaries['runBinary']);
             $versionCommand = "{$binaries['runBinary']} --version";
             $version = $this->loadVersionFromConsoleCommand($versionCommand);
             $composerInfo = [
@@ -76,8 +75,7 @@ class GetVersions
                 'authors' => [(object) ['name' => "<comment>{$versionCommand}</comment>"]],
             ];
         } elseif (!$composerPackages) {
-            $binary = \Edge\QA\escapePath($binaries['runBinary']);
-            $versionCommand = $tool == 'parallel-lint' ? $binary : "{$binary} --version";
+            $versionCommand = $tool == 'parallel-lint' ? $binaries['runBinary'] : "{$binaries['runBinary']} --version";
             $version = $this->loadVersionFromConsoleCommand($versionCommand);
             $composerInfo = [
                 'version' => $version,

--- a/src/Tools/GetVersions.php
+++ b/src/Tools/GetVersions.php
@@ -57,7 +57,6 @@ class GetVersions
 
     private function analyzeTool($tool, array $requiredPackages, array $composerPackages, $customBinary = null)
     {
-        $toolPackage = reset($requiredPackages);
         $notInstalledPackages = implode(' ', array_filter(
             $requiredPackages,
             function ($package) use ($composerPackages) {
@@ -66,6 +65,7 @@ class GetVersions
         ));
 
         if ($customBinary) {
+            $binary = \Edge\QA\escapePath($customBinary);
             $versionCommand = "{$customBinary} --version";
             $version = $this->loadVersionFromConsoleCommand($versionCommand);
             $composerInfo = [
@@ -74,7 +74,7 @@ class GetVersions
                 'authors' => [(object) ['name' => "<comment>{$versionCommand}</comment>"]],
             ];
         } elseif (!$composerPackages) {
-            $binary = \Edge\QA\pathToBinary($tool);
+            $binary = \Edge\QA\escapedPathToComposerBinary($tool);
             $versionCommand = $tool == 'parallel-lint' ? $binary : "{$binary} --version";
             $version = $this->loadVersionFromConsoleCommand($versionCommand);
             $composerInfo = [

--- a/src/Tools/Tool.php
+++ b/src/Tools/Tool.php
@@ -38,8 +38,10 @@ abstract class Tool
     protected function toolVersionIs($operator, $version)
     {
         $versions = new GetVersions();
+        $customBinary = $this->config->getCustomBinary((string) $this->tool);
         $settings = static::$SETTINGS + [
-            'customBinary' => $this->config->getCustomBinary((string) $this->tool),
+            'hasCustomBinary' => (bool) $customBinary,
+            'runBinary' => $customBinary ?: \Edge\QA\pathToComposerBinary((string) $this->tool),
         ];
         return $versions->hasToolVersion($settings, $operator, $version);
     }

--- a/src/Tools/Tool.php
+++ b/src/Tools/Tool.php
@@ -41,7 +41,7 @@ abstract class Tool
         $customBinary = $this->config->getCustomBinary((string) $this->tool);
         $settings = static::$SETTINGS + [
             'hasCustomBinary' => (bool) $customBinary,
-            'runBinary' => $customBinary ?: \Edge\QA\pathToComposerBinary((string) $this->tool),
+            'runBinary' => \Edge\QA\buildToolBinary((string) $this->tool, $customBinary),
         ];
         return $versions->hasToolVersion($settings, $operator, $version);
     }

--- a/src/Tools/Tools.php
+++ b/src/Tools/Tools.php
@@ -30,9 +30,11 @@ class Tools
                     if (!is_subclass_of($handler, $abstractTool)) {
                         die("Invalid handler for {$tool}. {$handler} is not subclass of '{$abstractTool}'\n");
                     }
+                    $customBinary = $this->config->getCustomBinary($tool);
                     return [
                         'handler' => $handler,
-                        'customBinary' => $this->config->getCustomBinary($tool),
+                        'hasCustomBinary' => (bool) $customBinary,
+                        'runBinary' => $customBinary ?: \Edge\QA\pathToComposerBinary($tool),
                     ] + $handler::$SETTINGS;
                 },
                 (array) $handler
@@ -72,11 +74,7 @@ class Tools
 
     public function buildCommand(RunningTool $tool, Options $o)
     {
-        $customBinary = $this->tools[(string) $tool]['customBinary'];
-        $binary = $customBinary
-            ? \Edge\QA\escapePath($customBinary)
-            : \Edge\QA\escapedPathToComposerBinary((string) $tool);
-
+        $binary = \Edge\QA\escapePath($this->tools[(string) $tool]['runBinary']);
         $handlerClass = $this->tools[(string) $tool]['handler'];
         $handler = new $handlerClass($this->config, $o, $tool, $this->presenter);
         $args = $handler($tool);

--- a/src/Tools/Tools.php
+++ b/src/Tools/Tools.php
@@ -34,7 +34,7 @@ class Tools
                     return [
                         'handler' => $handler,
                         'hasCustomBinary' => (bool) $customBinary,
-                        'runBinary' => $customBinary ?: \Edge\QA\pathToComposerBinary($tool),
+                        'runBinary' => \Edge\QA\buildToolBinary($tool, $customBinary),
                     ] + $handler::$SETTINGS;
                 },
                 (array) $handler
@@ -74,7 +74,7 @@ class Tools
 
     public function buildCommand(RunningTool $tool, Options $o)
     {
-        $binary = \Edge\QA\escapePath($this->tools[(string) $tool]['runBinary']);
+        $binary = $this->tools[(string) $tool]['runBinary'];
         $handlerClass = $this->tools[(string) $tool]['handler'];
         $handler = new $handlerClass($this->config, $o, $tool, $this->presenter);
         $args = $handler($tool);

--- a/src/Tools/Tools.php
+++ b/src/Tools/Tools.php
@@ -72,7 +72,10 @@ class Tools
 
     public function buildCommand(RunningTool $tool, Options $o)
     {
-        $binary = $this->tools[(string) $tool]['customBinary'] ?: \Edge\QA\pathToBinary((string) $tool);
+        $customBinary = $this->tools[(string) $tool]['customBinary'];
+        $binary = $customBinary
+            ? \Edge\QA\escapePath($customBinary)
+            : \Edge\QA\escapedPathToComposerBinary((string) $tool);
 
         $handlerClass = $this->tools[(string) $tool]['handler'];
         $handler = new $handlerClass($this->config, $o, $tool, $this->presenter);

--- a/src/paths.php
+++ b/src/paths.php
@@ -2,10 +2,18 @@
 
 namespace Edge\QA;
 
-function pathToComposerBinary($tool)
+function buildToolBinary($tool, $customBinary = null)
 {
-    $binary = COMPOSER_BINARY_DIR . $tool;
-    return is_file($binary) ? $binary : null;
+    return buildSafeBinary($customBinary ?: (COMPOSER_BINARY_DIR . $tool));
+}
+
+function buildSafeBinary($unsafeBinary)
+{
+    if (!$unsafeBinary || !is_file($unsafeBinary)) {
+        return "";
+    } else {
+        return escapePath($unsafeBinary);
+    }
 }
 
 function escapePath($path)

--- a/src/paths.php
+++ b/src/paths.php
@@ -2,7 +2,7 @@
 
 namespace Edge\QA;
 
-function pathToBinary($tool)
+function escapedPathToComposerBinary($tool)
 {
     return escapePath(COMPOSER_BINARY_DIR . $tool);
 }

--- a/src/paths.php
+++ b/src/paths.php
@@ -2,9 +2,10 @@
 
 namespace Edge\QA;
 
-function escapedPathToComposerBinary($tool)
+function pathToComposerBinary($tool)
 {
-    return escapePath(COMPOSER_BINARY_DIR . $tool);
+    $binary = COMPOSER_BINARY_DIR . $tool;
+    return is_file($binary) ? $binary : null;
 }
 
 function escapePath($path)

--- a/src/paths.php
+++ b/src/paths.php
@@ -11,8 +11,10 @@ function buildSafeBinary($unsafeBinary)
 {
     if (!$unsafeBinary || !is_file($unsafeBinary)) {
         return "";
-    } else {
+    } elseif (is_executable($unsafeBinary)) {
         return escapePath($unsafeBinary);
+    } else {
+        return 'php ' . escapePath($unsafeBinary);
     }
 }
 

--- a/tests/.ci/.phpqa.yml
+++ b/tests/.ci/.phpqa.yml
@@ -54,3 +54,10 @@ phpunit:
         file:
             log: [junit]
             testdox: [html, text]
+
+# example for running phpmetrics:v1, if v2 is installed in composer
+# $ phpqa --config tests/.ci/ --tools phpmetricsV1,phpmetrics
+#phpmetricsV1:
+#    binary: /usr/local/bin/phpmetrics.phar
+#tool:
+#    phpmetricsV1: Edge\QA\Tools\Analyzer\PhpMetrics

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -101,20 +101,18 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config->loadUserConfig('');
     }
 
-    public function testThrowExceptionWhenBinaryDoesNotExist()
+    public function testIgnoreInvalidBinaryDoesNotExist()
     {
         $config = new Config();
         $config->loadUserConfig(__DIR__);
-        $this->shouldStopPhpqa();
-        $config->getCustomBinary('phpunit');
+        assertThat($config->getCustomBinary('phpunit'), is(nullValue()));
     }
 
-    public function testThrowExceptionWhenWrongBinaryIsUsed()
+    public function testToolAndBinaryNameMightNotMatch()
     {
         $config = new Config();
         $config->loadUserConfig(__DIR__);
-        $this->shouldStopPhpqa();
-        $config->getCustomBinary('phpmetrics');
+        assertThat($config->getCustomBinary('phpmetrics'), is(notNullValue()));
     }
 
     public function testMultipleConfig()

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -154,6 +154,12 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
 
     private function buildRunningTools(Options $o, array $tools)
     {
+        foreach (array_keys($tools) as $tool) {
+            $tools[$tool] += [
+                'hasCustomBinary' => false,
+                'runBinary' => 'irrelevant',
+            ];
+        }
         return $o->buildRunningTools($tools);
     }
 }

--- a/tests/PathsTest.php
+++ b/tests/PathsTest.php
@@ -8,7 +8,7 @@ class PathsTest extends \PHPUnit_Framework_TestCase
     {
         define('COMPOSER_BINARY_DIR', '/home/user with space/phpqa/vendor/bin');
         $tool = 'irrelevant';
-        assertThat(buildToolBinary($tool, __FILE__), allOf(startsWith('"'), endsWith('"')));
+        assertThat(buildToolBinary($tool, __FILE__), allOf(startsWith('php "'), endsWith('"')));
         assertThat(buildToolBinary($tool, 'not-installed-tool'), is(''));
     }
 }

--- a/tests/PathsTest.php
+++ b/tests/PathsTest.php
@@ -7,6 +7,6 @@ class PathsTest extends \PHPUnit_Framework_TestCase
     public function testPathToBinaryIsEscaped()
     {
         define('COMPOSER_BINARY_DIR', '/home/user with space/phpqa/vendor/bin');
-        assertThat(escapedPathToComposerBinary('phpcs'), allOf(startsWith('"'), endsWith('"')));
+        assertThat(escapePath(COMPOSER_BINARY_DIR . 'phpcs'), allOf(startsWith('"'), endsWith('"')));
     }
 }

--- a/tests/PathsTest.php
+++ b/tests/PathsTest.php
@@ -7,6 +7,8 @@ class PathsTest extends \PHPUnit_Framework_TestCase
     public function testPathToBinaryIsEscaped()
     {
         define('COMPOSER_BINARY_DIR', '/home/user with space/phpqa/vendor/bin');
-        assertThat(escapePath(COMPOSER_BINARY_DIR . 'phpcs'), allOf(startsWith('"'), endsWith('"')));
+        $tool = 'irrelevant';
+        assertThat(buildToolBinary($tool, __FILE__), allOf(startsWith('"'), endsWith('"')));
+        assertThat(buildToolBinary($tool, 'not-installed-tool'), is(''));
     }
 }

--- a/tests/PathsTest.php
+++ b/tests/PathsTest.php
@@ -7,6 +7,6 @@ class PathsTest extends \PHPUnit_Framework_TestCase
     public function testPathToBinaryIsEscaped()
     {
         define('COMPOSER_BINARY_DIR', '/home/user with space/phpqa/vendor/bin');
-        assertThat(pathToBinary('phpcs'), allOf(startsWith('"'), endsWith('"')));
+        assertThat(escapedPathToComposerBinary('phpcs'), allOf(startsWith('"'), endsWith('"')));
     }
 }


### PR DESCRIPTION
Related: https://github.com/EdgedesignCZ/phpqa/pull/233, https://github.com/EdgedesignCZ/phpqa/pull/89/commits/300eb60ccd34a9de1008c8750f3d86b1172a8659

* [x] missing binary can't stop analysis - just ignore it, or show it in not installed tools
* [x] phar support - no `internalClass`, run phpmetrics v2 from composer and v1 from phar