### PR TITLE
CI - fix phpstan/psalm config

### DIFF
--- a/src/IgnoredPaths.php
+++ b/src/IgnoredPaths.php
@@ -24,7 +24,9 @@ class IgnoredPaths
 
     private function csvToArray($csv)
     {
-        return array_filter(explode(',', $csv), 'trim');
+        return array_filter(explode(',', $csv), function ($value) {
+            return (bool) trim($value);
+        });
     }
 
     public function phpcs()

--- a/src/Tools/Tool.php
+++ b/src/Tools/Tool.php
@@ -16,6 +16,8 @@ abstract class Tool
     protected $tool;
     /** @var \Closure */
     private $presenter;
+    /** @var array */
+    public static $SETTINGS = array();
 
     public function __construct(Config $c, Options $o, RunningTool $t, $presenter)
     {

--- a/tests/.appveyor/.phpqa.yml
+++ b/tests/.appveyor/.phpqa.yml
@@ -1,5 +1,6 @@
 phpqa:
     tools: phpmetrics,phploc,phpcs:0,php-cs-fixer,phpmd:0,pdepend,phpcpd:0,phpstan,phpunit:0,psalm,security-checker,parallel-lint
+    ignoredFiles: tests/.phpunit/fix-psalm-testcase.php
 
 phpcs:
     standard: ../.ci/phpcs.xml

--- a/tests/.ci/.phpqa.yml
+++ b/tests/.ci/.phpqa.yml
@@ -43,7 +43,7 @@ psalm:
     deadCode: true
 
 phpstan:
-    level: 7
+    level: 5 # last level without type hints
     # memoryLimit: 1G
     # https://github.com/phpstan/phpstan#configuration
     standard: phpstan.neon

--- a/tests/.ci/.phpqa.yml
+++ b/tests/.ci/.phpqa.yml
@@ -10,6 +10,7 @@ phpqa:
         # Fatal error: Uncaught UnexpectedValueException: RecursiveDirectoryIterator::__construct(/home/travis/build/EdgedesignCZ/phpqa/phpqa/):
         # failed to open dir: No such file or directory
         # https://travis-ci.org/EdgedesignCZ/phpqa/jobs/558458320#L799
+    ignoredFiles: tests/.phpunit/fix-psalm-testcase.php
     tools:
         - phpmetrics:0
         - phploc

--- a/tests/.ci/phpstan.neon
+++ b/tests/.ci/phpstan.neon
@@ -1,17 +1,28 @@
-# Required config for analyzing root directory (RobotLoader. throws Nette\InvalidStateException: Ambiguous class)
-#   phpqa --report --output cli --tools phpstan --analyzedDirs ./ --ignoredDirs=vendor
-
-parameters: 
-    bootstrap: %currentWorkingDirectory%/vendor/autoload.php
-    autoload_directories: 
-        - %currentWorkingDirectory%/tests 
-    autoload_files:
-        - %currentWorkingDirectory%/RoboFile.php
+parameters:
+    reportUnmatchedIgnoredErrors: false
     # exclude robo v0/v1 compatibility classes - it's not possible to analyze them with phsptan (only one robo version is installed)
     excludes_analyse:
+        - %currentWorkingDirectory%/src/Task/ParallelExec.php
         - %currentWorkingDirectory%/src/Task/NonParallelExecV0.php
         - %currentWorkingDirectory%/src/Task/NonParallelExecV1.php
         - %currentWorkingDirectory%/src/Task/RoboAdapter.php
     ignoreErrors:
-        - '#Call to an undefined method Prophecy\\Prophecy\\ObjectProphecy::[a-zA-Z0-9_]+\(\)#'
-        - '#Constant [A-Z_]+ not found#'
+        # constants from phpqa
+        - message: '#Constant COMPOSER_(.+) not found.#'
+          path: %currentWorkingDirectory%/src
+        - message: '#Constant PHPQA_(.+) not found.#'
+          path: %currentWorkingDirectory%/src
+        # phpqa specifics (multiple versions, compatibility classes, dynamic tools, ...)
+        - message: '#Call to an undefined static method#'
+          path: %currentWorkingDirectory%/src/Tools/GetVersions.php
+        - message: '#class Twig#'
+          path: %currentWorkingDirectory%/src/report.php
+        # multiple phpunit versions + hamcrest + prophecy
+        - message: '#Call to an undefined method(.+)Exception#'
+          path: %currentWorkingDirectory%/tests/Config/ConfigTest.php
+        - message: '#Function assertThat invoked with 2 parameters, 0 required.#'
+          path: %currentWorkingDirectory%/tests
+        - message: '#Function allOf invoked with (.+) parameters, 0 required.#'
+          path: %currentWorkingDirectory%/tests
+        - message: '#Call to an undefined method Prophecy#'
+          path: %currentWorkingDirectory%/tests

--- a/tests/.ci/psalm.xml
+++ b/tests/.ci/psalm.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0"?>
 <psalm
-    name="Psalm config for edgedesign/phpqa"
-    useDocblockTypes="true"
-    totallyTyped="false"
+    errorLevel="3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config ../../vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
         <ignoreFiles>
+            <file name="src/Task/ParallelExec.php" />
             <file name="src/Task/NonParallelExecV0.php" />
             <file name="src/Task/NonParallelExecV1.php" />
             <file name="src/Task/RoboAdapter.php" />
@@ -13,59 +15,47 @@
     </projectFiles>
 
     <issueHandlers>
-        <!-- phpqa specifics (compatibility classes, dynamic tools, ...) -->
-        <UnusedClass> 
-          <errorLevel type="info"> 
-            <directory name="tests" />
-            <directory name="src/Tools/Analyzer" />
-            <directory name="src/Task" />
-          </errorLevel> 
+        <!-- phpqa specifics (multiple versions, compatibility classes, dynamic tools, ...) -->
+        <UnusedClass>
+            <errorLevel type="info">
+                <directory name="tests" />
+                <directory name="src/Tools/Analyzer" />
+                <directory name="src/Task" />
+                <file name="RoboFile.php" />
+            </errorLevel>
         </UnusedClass>
         <PossiblyUnusedMethod>
-          <errorLevel type="info">
-            <file name="src/CodeAnalysisTasks.php" />
-            <file name="src/Tools/Tool.php" />
-            <file name="src/Tools/Tools.php" />
-            <file name="src/RunningTool.php" />
-          </errorLevel>
-          <errorLevel type="suppress"> 
-            <directory name="tests" />
-          </errorLevel> 
+            <errorLevel type="info">
+                <file name="src/CodeAnalysisTasks.php" />
+                <file name="src/RunningTool.php" />
+            </errorLevel>
         </PossiblyUnusedMethod>
-        <InvalidReturnType>
-          <errorLevel type="info">
-            <file name="src/Task/ParallelExec.php" />
-          </errorLevel>
-        </InvalidReturnType>
-        <DeprecatedMethod errorLevel="info" /> 
-
-        <!-- Ignored rules -->
-        <PropertyNotSetInConstructor errorLevel="info" />
+        <PossiblyInvalidArgument>
+            <errorLevel type="info">
+                <file name="src/paths.php" />
+            </errorLevel>
+        </PossiblyInvalidArgument>
+        <PossiblyInvalidCast>
+            <errorLevel type="info">
+                <file name="src/paths.php" />
+            </errorLevel>
+        </PossiblyInvalidCast>
+        <ArgumentTypeCoercion errorLevel="info" />
+        <PropertyTypeCoercion errorLevel="info" />
+        <PossiblyFalseOperand errorLevel="info" />
         <UndefinedConstant errorLevel="info" />
-        <MissingReturnType errorLevel="suppress" />
-        <MissingPropertyType errorLevel="suppress" />
-        <MissingClosureReturnType errorLevel="suppress" />
-        <MissingConstructor errorLevel="suppress" />
-        <PossiblyUnusedParam errorLevel="info" />
+        <UndefinedClass errorLevel="info" />
+        <UndefinedMethod errorLevel="info" />
+        <InvalidArrayOffset errorLevel="info" />
+        <InvalidFunctionCall errorLevel="info" />
+        <InvalidReturnType errorLevel="info" />
+        <ReservedWord errorLevel="info" />
 
         <!-- false positive -->
-        <UnusedVariable errorLevel="info" />
-        <UndefinedThisPropertyAssignment errorLevel="info" />
-        <TooFewArguments> 
-          <errorLevel type="info"> 
-            <file name="src/report.php" /><!-- Too few arguments for method XSLTProcessor::setparameter --> 
-          </errorLevel> 
-        </TooFewArguments> 
-        <TooManyArguments> 
-          <errorLevel type="suppress"> 
-            <directory name="tests" /><!-- Too many arguments for method assertthat --> 
-          </errorLevel> 
+        <TooManyArguments>
+            <errorLevel type="info">
+                <directory name="tests" /><!-- Too many arguments for Prophecy -->
+            </errorLevel>
         </TooManyArguments>
-        <PossiblyFalseArgument>
-          <errorLevel type="info">
-            <file name="src/Task/AssetsLoader.php" /><!-- Argument 1 of curl_setopt expects resource, possibly different type resource|false provided --> 
-          </errorLevel>
-        </PossiblyFalseArgument>
-        
     </issueHandlers>
 </psalm>

--- a/tests/.phpunit/fix-psalm-testcase.php
+++ b/tests/.phpunit/fix-psalm-testcase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace
+{
+    use PHPUnit\Framework\TestCase;
+
+    abstract class PHPUnit_Framework_TestCase extends TestCase
+    {
+    }
+}

--- a/tests/.phpunit/fix-testcase.php
+++ b/tests/.phpunit/fix-testcase.php
@@ -2,5 +2,9 @@
 
 $legacyTestClass = 'PHPUnit_Framework_TestCase';
 if (!class_exists($legacyTestClass)) {
-    class_alias('PHPUnit\Framework\TestCase', $legacyTestClass);
+    // `class_alias('PHPUnit\Framework\TestCase', $legacyTestClass);` does not work for psalm:
+    // > Could not get class storage for phpunit_framework_testcase"
+    // > https://github.com/EdgedesignCZ/phpqa/runs/2581795905?check_suite_focus=true#step:7:246
+    // > https://github.com/psalm/psalm-plugin-phpunit/issues/30#issuecomment-485485187
+    include_once(__DIR__ . "/fix-psalm-testcase.php");
 }


### PR DESCRIPTION
* [x] phpstan - use level that does not require type hint for everything, don't use [deprecated config](https://github.com/EdgedesignCZ/phpqa/runs/2475678048?check_suite_focus=true#step:7:757)
* [x] psalm - fix phpunit testcase alias, use [level](https://psalm.dev/docs/running_psalm/error_levels/) that does not require type hint for everything

Checking exit code can't be reverted to zero, because [php7.2](https://github.com/EdgedesignCZ/phpqa/runs/2582088591?check_suite_focus=true#step:7:30) without updated dependencies does not work:

* old psalm version causes `The attribute 'errorLevel' is not allowed.`
* phpstan + phpmetrics v1 = `Hoa main file (Core.php) must be included once.`

![psalm error](https://user-images.githubusercontent.com/7994022/118240354-33632c00-b49b-11eb-9f7d-93afa430f646.png)
![phpstan error](https://user-images.githubusercontent.com/7994022/118240359-34945900-b49b-11eb-9e6c-61dd60f58d8b.png)
