### PR TITLE
#241 phpstan - fix deprecated excludes_analyse

### DIFF
--- a/src/Tools/Analyzer/Phpstan.php
+++ b/src/Tools/Analyzer/Phpstan.php
@@ -32,19 +32,19 @@ class Phpstan extends \Edge\QA\Tools\Tool
         if (file_exists($defaultConfig)) {
             $config = \Nette\Neon\Neon::decode(file_get_contents($defaultConfig));
             $config['parameters'] += [
-                'excludes_analyse' => [],
+                'excludePaths' => [],
             ];
         } else {
             $config = [
                 'parameters' => [
                     'autoload_directories' => $createAbsolutePaths($this->options->getAnalyzedDirs()),
-                    'excludes_analyse'     => [],
+                    'excludePaths'         => [],
                 ],
             ];
         }
 
-        $config['parameters']['excludes_analyse'] = array_merge(
-            $config['parameters']['excludes_analyse'],
+        $config['parameters']['excludePaths'] = array_merge(
+            $config['parameters']['excludePaths'],
             $createAbsolutePaths($this->options->ignore->phpstan())
         );
 

--- a/src/Tools/Analyzer/Phpstan.php
+++ b/src/Tools/Analyzer/Phpstan.php
@@ -44,7 +44,7 @@ class Phpstan extends \Edge\QA\Tools\Tool
         }
 
         $config['parameters']['excludePaths'] = array_merge(
-            $config['parameters']['excludePaths'],
+            $config['parameters']['excludePaths']['analyseAndScan'] ?? $config['parameters']['excludePaths'],
             $createAbsolutePaths($this->options->ignore->phpstan())
         );
 

--- a/src/Tools/Analyzer/Phpstan.php
+++ b/src/Tools/Analyzer/Phpstan.php
@@ -32,19 +32,23 @@ class Phpstan extends \Edge\QA\Tools\Tool
         if (file_exists($defaultConfig)) {
             $config = \Nette\Neon\Neon::decode(file_get_contents($defaultConfig));
             $config['parameters'] += [
-                'excludePaths' => [],
+                'excludePaths' => [
+                    'analyseAndScan' => [],
+                ],
             ];
         } else {
             $config = [
                 'parameters' => [
                     'autoload_directories' => $createAbsolutePaths($this->options->getAnalyzedDirs()),
-                    'excludePaths'         => [],
+                    'excludePaths'         => [
+                        'analyseAndScan' => [],
+                    ],
                 ],
             ];
         }
 
-        $config['parameters']['excludePaths'] = array_merge(
-            $config['parameters']['excludePaths']['analyseAndScan'] ?? $config['parameters']['excludePaths'],
+        $config['parameters']['excludePaths']['analyseAndScan'] = array_merge(
+            isset($config['parameters']['excludePaths']['analyseAndScan']) ? $config['parameters']['excludePaths']['analyseAndScan'] : [],
             $createAbsolutePaths($this->options->ignore->phpstan())
         );
 


### PR DESCRIPTION
As reported by @oussamalamlihe on issue #241 Phpstan now use only `excludePaths` to exclude files from analysis.
Here is a PR for this issue.

Phpstan doc: https://phpstan.org/user-guide/ignoring-errors#excluding-whole-files
Phpstan issue where it has been changed: https://github.com/phpstan/phpstan/issues/3749