### PR TITLE
security-checker - enable overriding composer.lock location

### DIFF
--- a/.phpqa.yml
+++ b/.phpqa.yml
@@ -91,6 +91,9 @@ psalm:
 deptrac:
     depfile: null # depfile.yml (https://github.com/qossmic/deptrac#the-depfile)
 
+security-checker:
+    composerLock: null # use it if composer.lock is not in current working directory or analyzed directory
+
 # paths are relative to .phpqa.yml, so don't copy-paste this section if you don't have custom templates
 report:
     phploc: app/report/phploc.xsl

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Tool | Settings | Default Value | Your value
 [psalm.showInfo](https://github.com/vimeo/psalm/wiki/Running-Psalm#command-line-options) | Display or not information (non-error) messages (option `--show-info=` of psalm) | `true` | Boolean value
 [psalm.memoryLimit](https://github.com/vimeo/psalm/issues/842) | Custom memory limit, ignore unless you are getting `Fatal error: Allowed memory size of ... bytes exhausted` | `null` | String value, e.g. `'1024M'`, `'1G'`
 [deptrac.depfile](https://github.com/vimeo/psalm/wiki/Configuration) | Complete [deptract config](https://github.com/qossmic/deptrac#getting-started) _(phpqa won't update source and excluded files)_ | `null` | Path to `depfile.yml` file
+[composer.lock](https://github.com/EdgedesignCZ/phpqa/blob/master/.phpqa.yml#L94) | Use it if composer.lock is not in current working directory or analyzed directory | `null` | Path to `composer.lock` file
 
 ## HTML reports
 

--- a/src/Tools/Analyzer/SecurityChecker.php
+++ b/src/Tools/Analyzer/SecurityChecker.php
@@ -14,18 +14,26 @@ class SecurityChecker extends \Edge\QA\Tools\Tool
 
     public function __invoke()
     {
-        $composerLock = getcwd() . "/composer.lock";
-        foreach ($this->options->getAnalyzedDirs() as $escapedDir) {
-            $dir = rtrim(trim($escapedDir, '"'), '/');
-            $path = "{$dir}/composer.lock";
-            if (file_exists($path)) {
-                $composerLock = $path;
-                break;
-            }
-        }
+        $composerLockFromConfig = $this->config->path('security-checker.composerLock');
+        $composerLock = file_exists($composerLockFromConfig)
+            ? $composerLockFromConfig
+            : $this->detectComposerLock();
+
         return [
             'security:check',
             $composerLock,
         ];
+    }
+
+    private function detectComposerLock()
+    {
+        foreach ($this->options->getAnalyzedDirs() as $escapedDir) {
+            $dir = rtrim(trim($escapedDir, '"'), '/');
+            $path = "{$dir}/composer.lock";
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+        return getcwd() . '/composer.lock';
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -38,6 +38,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         assertThat($config->value('phpmetrics.git'), identicalTo(false));
         assertThat($config->value('pdepend.coverageReport'), is(nullValue()));
         assertThat($config->value('deptrac.depfile'), is(nullValue()));
+        assertThat($config->value('security-checker.composerLock'), is(nullValue()));
     }
 
     public function testBuildAbsolutePath()


### PR DESCRIPTION
Necessary if only `src/` directory is analyzed in monorepo