### PR TITLE
Append suffixes correctly for phpcpd

### DIFF
--- a/src/Tools/Analyzer/Phpcpd.php
+++ b/src/Tools/Analyzer/Phpcpd.php
@@ -31,12 +31,12 @@ class Phpcpd extends \Edge\QA\Tools\Tool
         }
         if ($phpcpdNames) {
             if ($isOlderVersion) {
-              $args['names'] = \Edge\QA\escapePath(implode(',', $phpcpdNames));
+                $args['names'] = \Edge\QA\escapePath(implode(',', $phpcpdNames));
             }
             else {
-              foreach ($phpcpdNames as $name) {
-                $args[] = '--suffix "' . \Edge\QA\escapePath($name) . '"';
-              }
+                foreach ($phpcpdNames as $name) {
+                    $args[] = '--suffix "' . \Edge\QA\escapePath($name) . '"';
+                }
             }
         }
         if ($this->options->isSavedToFiles) {

--- a/src/Tools/Analyzer/Phpcpd.php
+++ b/src/Tools/Analyzer/Phpcpd.php
@@ -34,7 +34,7 @@ class Phpcpd extends \Edge\QA\Tools\Tool
                 $args['names'] = \Edge\QA\escapePath(implode(',', $phpcpdNames));
             } else {
                 foreach ($phpcpdNames as $name) {
-                    $args[] = '--suffix "' . \Edge\QA\escapePath($name) . '"';
+                    $args[] = sprintf('--suffix %s', \Edge\QA\escapePath($name));
                 }
             }
         }

--- a/src/Tools/Analyzer/Phpcpd.php
+++ b/src/Tools/Analyzer/Phpcpd.php
@@ -32,8 +32,7 @@ class Phpcpd extends \Edge\QA\Tools\Tool
         if ($phpcpdNames) {
             if ($isOlderVersion) {
                 $args['names'] = \Edge\QA\escapePath(implode(',', $phpcpdNames));
-            }
-            else {
+            } else {
                 foreach ($phpcpdNames as $name) {
                     $args[] = '--suffix "' . \Edge\QA\escapePath($name) . '"';
                 }

--- a/src/Tools/Analyzer/Phpcpd.php
+++ b/src/Tools/Analyzer/Phpcpd.php
@@ -30,8 +30,14 @@ class Phpcpd extends \Edge\QA\Tools\Tool
             $args['progress'] = '';
         }
         if ($phpcpdNames) {
-            $namesOptions = $isOlderVersion ? 'names' : 'suffix';
-            $args[$namesOptions] = \Edge\QA\escapePath(implode(',', $phpcpdNames));
+            if ($isOlderVersion) {
+              $args['names'] = \Edge\QA\escapePath(implode(',', $phpcpdNames));
+            }
+            else {
+              foreach ($phpcpdNames as $name) {
+                $args[] = '--suffix "' . \Edge\QA\escapePath($name) . '"';
+              }
+            }
         }
         if ($this->options->isSavedToFiles) {
             $args['log-pmd'] = $this->tool->getEscapedXmlFile();


### PR DESCRIPTION
Since phpcpd has released the 6.0 version the --names have been removed in favour of the new argument --suffix. This change has been adapted at PHPqa project but it needs a correction. 

CUrrently, the --suffix arguments is added by joining all the suffixes by commas. Example:

```bash
--suffix="*.php,*.theme,*.module"
```

But that syntax is not correct. This is the documentation of the suffix command from PHPcpd:

```bash
  --suffix <suffix> Include files with names ending in <suffix> in the analysis
                    (default: .php; can be given multiple times)
```

The suffix parameter only accepts one suffix, and if it is needed to add more suffixes, the --suffix parameter must be repeated. So, the example I shown below should be corrected to this:

```bash
--suffix="*.php,*.theme,*.module" --suffix="*.module" --suffix="*.theme"
```

This pull request fixes the usage of suffix to be added by repeating suffix arguments and not joining the suffixes by commas. Please review, thanks!

