### PR TITLE
CI - hotfix allowed security-checker errors for php5.6

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
         include:    
           # PHP5
           - { php: 5.4, areSuggestedToolsInstalled: yes }
-          - { php: 5.6, isComposerUpdated: yes, areSuggestedToolsInstalled: yes }
+          - { php: 5.6, isComposerUpdated: yes, areSuggestedToolsInstalled: yes, allowedSecurityErrors: 1 }
           # PHP7
           - { php: 7.0 }
           - { php: 7.1, isComposerUpdated: yes, areSuggestedToolsInstalled: yes }
@@ -68,6 +68,8 @@ jobs:
         ./phpqa tools --config tests/.ci 
 
     - name: Run tests
+      env:
+        ALLOWED_SECURITY_ERRORS: ${{ matrix.allowedSecurityErrors || '' }}
       run: |
         vendor/phpunit/phpunit/phpunit
         bin/ci.sh

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,3 +1,22 @@
 #!/bin/sh
 
-./phpqa --config tests/.ci
+ALLOWED_SECURITY_ERRORS=${ALLOWED_SECURITY_ERRORS:-""}
+
+run () {
+    hotfix_security_checker_for_php5
+    run_phpqa
+}
+
+hotfix_security_checker_for_php5 () {
+    if [ -n "$ALLOWED_SECURITY_ERRORS" ]; then
+        echo "Updating security-checker errors to $ALLOWED_SECURITY_ERRORS..."
+        sed -i -e "s/security-checker:0/security-checker:$ALLOWED_SECURITY_ERRORS/g" tests/.ci/.phpqa.yml
+    fi
+}
+
+run_phpqa () {
+    ./phpqa --config tests/.ci
+}
+
+run
+


### PR DESCRIPTION
https://github.com/EdgedesignCZ/phpqa/security/dependabot/1 twig v1.44.7 requires php >=7.2.5
https://github.com/twigphp/Twig/blob/1.x/composer.json#L27