### PR TITLE
phpqa - use printTaskSuccess/printTaskError instead of printTaskOutput and remove use of Consolidation\Log\ConsoleLogLevel

### DIFF
--- a/src/Task/NonParallelExecV1.php
+++ b/src/Task/NonParallelExecV1.php
@@ -2,7 +2,6 @@
 
 namespace Edge\QA\Task;
 
-use Consolidation\Log\ConsoleLogLevel;
 use Robo\Result;
 use Symfony\Component\Process\Process;
 
@@ -61,9 +60,9 @@ class NonParallelExecV1 extends ParallelExec
         $this->printTaskInfo(
             "Output for <fg=white;bg=magenta> " . $process->getCommandLine()." </fg=white;bg=magenta>"
         );
-        $this->printTaskOutput(ConsoleLogLevel::SUCCESS, $process->getOutput(), $this->getTaskContext());
+        $this->printTaskSuccess($process->getOutput(), $this->getTaskContext());
         if ($process->getErrorOutput()) {
-            $this->printTaskOutput(ConsoleLogLevel::ERROR, $process->getErrorOutput(), $this->getTaskContext());
+            $this->printTaskError($process->getErrorOutput(), $this->getTaskContext());
         }
     }
 }


### PR DESCRIPTION
Hello 👋 

My project uses Drupal 10 and Drush 11.

**Problem :** 

```
ERROR: Uncaught Error: Class "Consolidation\Log\ConsoleLogLevel" not found in /var/www/html/vendor/edgedesign/phpqa/src/Task/NonParallelExecV1.php:64
Stack trace:
#0 /var/www/html/vendor/edgedesign/phpqa/src/Task/NonParallelExecV1.php(36): Edge\QA\Task\NonParallelExecV1->printProcessResult()
#1 /var/www/html/vendor/consolidation/robo/src/Collection/CollectionBuilder.php(606): Edge\QA\Task\NonParallelExecV1->run()
#2 /var/www/html/vendor/consolidation/robo/src/Collection/CollectionBuilder.php(590): Robo\Collection\CollectionBuilder->runTasks()
#3 /var/www/html/vendor/edgedesign/phpqa/src/CodeAnalysisTasks.php(146): Robo\Collection\CollectionBuilder->run()
#4 /var/www/html/vendor/edgedesign/phpqa/src/CodeAnalysisTasks.php(58): Edge\QA\RoboFile->runTools()
#5 [internal function]: Edge\QA\RoboFile->ci()
#6 /var/www/html/vendor/consolidation/annotated-command/src/CommandProcessor.php(257): call_user_func_array()
#7 /var/www/html/vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback()
#8 /var/www/html/vendor/consolidation/annotated-command/src/CommandProcessor.php(175): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter()
#9 /var/www/html/vendor/consolidation/annotated-command/src/AnnotatedCommand.php(386): Consolidation\AnnotatedCommand\CommandProcessor->process()
#10 /var/www/html/vendor/symfony/console/Command/Command.php(312): Consolidation\AnnotatedCommand\AnnotatedCommand->execute()
#11 /var/www/html/vendor/symfony/console/Application.php(1040): Symfony\Component\Console\Command\Command->run()
#12 /var/www/html/vendor/symfony/console/Application.php(314): Symfony\Component\Console\Application->doRunCommand()
#13 /var/www/html/vendor/symfony/console/Application.php(168): Symfony\Component\Console\Application->doRun()
#14 /var/www/html/vendor/consolidation/robo/src/Runner.php(282): Symfony\Component\Console\Application->run()
#15 /var/www/html/vendor/consolidation/robo/src/Runner.php(158): Robo\Runner->run()
#16 /var/www/html/vendor/edgedesign/phpqa/phpqa(58): Robo\Runner->execute()
#17 /var/www/html/vendor/bin/phpqa(120): include('...')
#18 {main}
  thrown
in /var/www/html/vendor/edgedesign/phpqa/src/Task/NonParallelExecV1.php:64
```
**Cause :**

Caused by https://github.com/consolidation/log/commit/12d16fd85830489eaf1c1cd25ae83c384e3503bb

**Reproduce :**

```
$ php -v
PHP 8.2.3 (cli) (built: Feb 14 2023 20:52:32) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.3, Copyright (c) Zend Technologies
    with Zend OPcache v8.2.3, Copyright (c), by Zend Technologies
```

```
$ composer why consolidation/log
consolidation/robo 4.0.3 requires consolidation/log (^2.0.2 || ^3) 
```

```
$ composer why consolidation/robo
drush/drush      11.5.1  requires consolidation/robo (^3.0.9 || ^4.0.1) 
edgedesign/phpqa v1.26.2 requires consolidation/robo (~0.5|>=1)
```