### PR TITLE
Remove automatic install of phpcpd

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Will you create e.g. Jenkins project/task for each bundle?
 Tool| Description
 ----------------------------------------------------------------------- | ----------------------------- |
 [phploc](https://github.com/sebastianbergmann/phploc) | Measure the size of a PHP project |
-[phpcpd](https://github.com/sebastianbergmann/phpcpd) | Copy/Paste Detector (CPD) for PHP code |
 [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) | Detect violations of a coding standard |
 [pdepend](https://github.com/pdepend/pdepend) | PHP adaptation of JDepend |
 [phpmd](https://github.com/phpmd/phpmd) | Scan PHP project for messy code |
@@ -57,6 +56,7 @@ Tool | PHP | Supported since | Description |
 [parallel-lint](https://github.com/JakubOnderka/PHP-Parallel-Lint) | `>= 5.4` | `1.9` | Check syntax of PHP files |
 [deptrac](https://github.com/qossmic/deptrac) | `>= 7.2` | `1.25` | Enforce rules for dependencies between software layers |
 [MacFJA/phpqa-extensions](https://github.com/MacFJA/phpqa-extensions) | - | - | PHP Assumptions, Magic Number Detector, ... |
+[phpcpd](https://github.com/sebastianbergmann/phpcpd) | - | - | PCopy/Paste Detector (CPD) for PHP code |
 
 _Tip_: use [`bin/suggested-tools.sh install`](/bin/suggested-tools.sh) for installing the tools.
 

--- a/bin/suggested-tools.sh
+++ b/bin/suggested-tools.sh
@@ -40,7 +40,7 @@ show_help() {
 }
 
 get_tools () {
-    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter friendsofphp/php-cs-fixer"
+    TOOLS="php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter friendsofphp/php-cs-fixer sebastian/phpcpd"
     if [[ ${PHP_VERSION:0:1} != "5" ]]; then
         TOOLS="${TOOLS} vimeo/psalm phpstan/phpstan nette/neon qossmic/deptrac-shim enlightn/security-checker"
     fi

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "symfony/yaml": ">=2.8",
         "twig/twig": "~1.38|~2.7|~3",
         "pdepend/pdepend": "*",
-        "sebastian/phpcpd": "*",
         "squizlabs/php_codesniffer": "*",
         "phpmetrics/phpmetrics": "*"
     },
@@ -41,7 +40,8 @@
         "vimeo/psalm": "A static analysis tool for finding errors in PHP applications",
         "php-parallel-lint/php-parallel-lint": "Check PHP syntax",
         "php-parallel-lint/php-console-highlighter": "Colored output in parallel-lint",
-        "qossmic/deptrac-shim": "Enforce rules for dependencies between software layers"
+        "qossmic/deptrac-shim": "Enforce rules for dependencies between software layers",
+        "sebastian/phpcpd": "A Copy/Paste Detector (CPD) for PHP code."
     },
     "require-dev": {
         "hamcrest/hamcrest-php": ">=2.0.1",


### PR DESCRIPTION
Remove phpcpd from composer requirements. 
The sebastian/phpcpd package is abandoned => https://github.com/sebastianbergmann/phpcpd

see: https://github.com/EdgedesignCZ/phpqa/issues/259