### PR TITLE
Fix php 8.5 deprecation (null array offset)

### DIFF
--- a/src/RunningTool.php
+++ b/src/RunningTool.php
@@ -13,8 +13,8 @@ class RunningTool
     private $outputMode;
 
     private $xmlFiles;
-    private $errorsXPath;
-    public $errorsType;
+    private $errorsXPath = '';
+    public $errorsType = '';
     private $allowedErrorsCount;
 
     public $htmlReport;


### PR DESCRIPTION
> https://github.com/EdgedesignCZ/phpqa/actions/runs/19562838640/job/56018405752#step:7:467
> ERROR: Using null as an array offset is deprecated, use an empty string instead in src/RunningTool.php:43